### PR TITLE
More Python3 compatibility

### DIFF
--- a/perf/create_synthetic_repo.py
+++ b/perf/create_synthetic_repo.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+
+
 next_mark = 1
 def get_mark():
     global next_mark
@@ -5,33 +8,33 @@ def get_mark():
     return (next_mark - 1)
 
 def write_data(s):
-    print 'data %d' % len(s)
-    print s
+    print('data %d' % len(s))
+    print(s)
 
 def write_blob(s):
-    print 'blob'
+    print('blob')
     m = get_mark()
-    print 'mark :%d' % m
+    print('mark :%d' % m)
     write_data(s)
     return m
 
 def write_commit(branch, files, msg, parent = None):
-    print 'commit %s' % branch
+    print('commit %s' % branch)
     m = get_mark()
-    print 'mark :%d' % m
+    print('mark :%d' % m)
     auth = 'X Ample <xa@example.com> %d +0000' % (1000000000 + m)
-    print 'author %s' % auth
-    print 'committer %s' % auth
+    print('author %s' % auth)
+    print('committer %s' % auth)
     write_data(msg)
     if parent is not None:
-        print 'from :%d' % parent
+        print('from :%d' % parent)
     for fn, fm in sorted(files.iteritems()):
-        print 'M 100644 :%d %s' % (fm, fn)
+        print('M 100644 :%d %s' % (fm, fn))
     return m
 
 def set_ref(ref, mark):
-    print 'reset %s' % ref
-    print 'from :%d' % mark
+    print('reset %s' % ref)
+    print('from :%d' % mark)
 
 def stdblob(fn):
     return ''.join('%d %s\n' % (x, fn) for x in xrange(10))

--- a/perf/find_patchbomb.py
+++ b/perf/find_patchbomb.py
@@ -1,5 +1,5 @@
 # Feed this with git rev-list HEAD --parents
-
+from __future__ import print_function
 import sys
 
 parents = {}
@@ -28,4 +28,4 @@ for commit in parents.keys():
 
 (num, commit) = max((num, commit) for (commit, num)
                     in sequence_num.iteritems())
-print '%s is a sequence of %d patches' % (commit, num)
+print('%s is a sequence of %d patches' % (commit, num))

--- a/perf/perftest.py
+++ b/perf/perftest.py
@@ -1,4 +1,7 @@
-import datetime, os, os.path, subprocess, sys
+import datetime
+import os
+import subprocess
+import sys
 
 def duration(t1, t2):
     d = t2 - t1

--- a/perf/perftest.py
+++ b/perf/perftest.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import datetime
 import os
 import subprocess
@@ -39,8 +40,8 @@ class Run(object):
         cl = max(len(pcmd(c)) for c in cs)
         tl = max(len(ptime(t)) for t in list(times) + [ttime])
         for (c, t) in self.__log:
-            print '%*s  %*s' % (tl, ptime(t), -cl, pcmd(c))
-        print '%*s' % (tl, ptime(ttime))
+            print('%*s  %*s' % (tl, ptime(t), -cl, pcmd(c)))
+        print('%*s' % (tl, ptime(ttime)))
 
 perftests = {}
 perftestdesc = {}
@@ -93,7 +94,7 @@ for rebase in ['old', 'new']:
 args = sys.argv[1:]
 if len(args) == 0:
     for (fun, desc) in sorted(perftestdesc.iteritems()):
-        print '%s: %s' % (fun, desc)
+        print('%s: %s' % (fun, desc))
 else:
     for test in args:
         perftests[test]()

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python2
 
-import sys, glob, os
+import glob
+import os
+import sys
 from distutils.core import setup
 
 from stgit import version

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ __check_python_version()
 __check_git_version()
 
 # ensure readable template files
-old_mask = os.umask(0022)
+old_mask = os.umask(0o022)
 
 version.write_builtin_version()
 

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-
+from __future__ import print_function
 import glob
 import os
 import sys
@@ -32,8 +32,8 @@ def __check_python_version():
     """
     pyver = '.'.join(map(str, sys.version_info))
     if not __check_min_version(version.python_min_ver, pyver):
-        print >> sys.stderr, 'Python version %s or newer required. Found %s' \
-              % (version.python_min_ver, pyver)
+        print('Python version %s or newer required. Found %s'
+              % (version.python_min_ver, pyver), file=sys.stderr)
         sys.exit(1)
 
 def __check_git_version():
@@ -42,8 +42,8 @@ def __check_git_version():
     from stgit.run import Run
     gitver = Run('git', '--version').output_one_line().split()[2]
     if not __check_min_version(version.git_min_ver, gitver):
-        print >> sys.stderr, 'GIT version %s or newer required. Found %s' \
-              % (version.git_min_ver, gitver)
+        print('GIT version %s or newer required. Found %s'
+              % (version.git_min_ver, gitver), file=sys.stderr)
         sys.exit(1)
 
 def __run_setup():

--- a/setup.py
+++ b/setup.py
@@ -90,14 +90,12 @@ old_mask = os.umask(0o022)
 version.write_builtin_version()
 
 # generate the python command list
-f = file('stgit/commands/cmdlist.py', 'w')
-commands.py_commands(commands.get_commands(allow_cached = False), f)
-f.close()
+with open('stgit/commands/cmdlist.py', 'w') as f:
+    commands.py_commands(commands.get_commands(allow_cached = False), f)
 
 # generate the bash completion script
-f = file('stgit-completion.bash', 'w')
-completion.write_completion(f)
-f.close()
+with open('stgit-completion.bash', 'w') as f:
+    completion.write_completion(f)
 
 __run_setup()
 

--- a/setup.py
+++ b/setup.py
@@ -72,8 +72,6 @@ def __run_setup():
               'Operating System :: OS Independent',
               'Programming Language :: Python',
               'Programming Language :: Python :: 2',
-              'Programming Language :: Python :: 2.4',
-              'Programming Language :: Python :: 2.5',
               'Programming Language :: Python :: 2.6',
               'Programming Language :: Python :: 2.7',
               'Programming Language :: Python :: Implementation :: CPython',

--- a/stgit/argparse.py
+++ b/stgit/argparse.py
@@ -152,9 +152,8 @@ def message_options(save_template):
         if value == '-':
             parser.values.message = sys.stdin.read()
         else:
-            f = file(value)
-            parser.values.message = f.read()
-            f.close()
+            with open(value) as f:
+                parser.values.message = f.read()
         no_combine(parser)
     def templ_callback(option, opt_str, value, parser):
         if value == '-':
@@ -162,9 +161,8 @@ def message_options(save_template):
                 sys.stdout.write(s)
         else:
             def w(s):
-                f = file(value, 'w+')
-                f.write(s)
-                f.close()
+                with open(value, 'w+') as f:
+                    f.write(s)
         parser.values.save_template = w
         no_combine(parser)
     opts = [

--- a/stgit/argparse.py
+++ b/stgit/argparse.py
@@ -2,7 +2,10 @@
 C{optparse} module, so that we can easily generate both interactive
 help and asciidoc documentation (such as man pages)."""
 
-import optparse, sys, textwrap
+import optparse
+import sys
+import textwrap
+
 from stgit import utils
 from stgit.config import config
 from stgit.lib import git

--- a/stgit/basedir.py
+++ b/stgit/basedir.py
@@ -18,7 +18,7 @@ along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
 import os
-from stgit.run import *
+from stgit.run import Run, RunException
 
 # GIT_DIR value cached
 __base_dir = None

--- a/stgit/commands/branch.py
+++ b/stgit/commands/branch.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 __copyright__ = """
 Copyright (C) 2005, Chuck Lever <cel@netapp.com>
 
@@ -383,4 +385,4 @@ def func(parser, options, args):
     if len(args) != 0:
         parser.error('incorrect number of arguments')
 
-    print crt_series.get_name()
+    print(crt_series.get_name())

--- a/stgit/commands/branch.py
+++ b/stgit/commands/branch.py
@@ -14,12 +14,18 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os, time, re
+import re
+import time
+
 from stgit.argparse import opt
-from stgit.commands.common import *
-from stgit.utils import *
-from stgit.out import *
-from stgit import argparse, stack, git, basedir
+from stgit.commands.common import (CmdException,
+                                   DirectoryGotoToplevel,
+                                   check_local_changes,
+                                   check_conflicts,
+                                   check_head_top_equal,
+                                   git_id)
+from stgit.out import out
+from stgit import argparse, stack, git
 from stgit.lib import log
 
 help = 'Branch operations: switch, list, create, rename, delete, ...'

--- a/stgit/commands/clean.py
+++ b/stgit/commands/clean.py
@@ -15,7 +15,6 @@ along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
 from stgit.argparse import opt
-from stgit.out import *
 from stgit.commands import common
 from stgit.lib import transaction
 

--- a/stgit/commands/clone.py
+++ b/stgit/commands/clone.py
@@ -18,7 +18,6 @@ import os
 from stgit.commands import common
 from stgit.lib import git, stack
 from stgit import argparse
-from stgit.out import out
 
 help = 'Make a local clone of a remote repository'
 kind = 'repo'

--- a/stgit/commands/commit.py
+++ b/stgit/commands/commit.py
@@ -17,7 +17,7 @@ along with this program; if not, see http://www.gnu.org/licenses/.
 from stgit.argparse import opt
 from stgit.commands import common
 from stgit.lib import transaction
-from stgit.out import *
+from stgit.out import out
 from stgit import argparse
 
 help = 'Permanently store the applied patches into the stack base'

--- a/stgit/commands/common.py
+++ b/stgit/commands/common.py
@@ -17,13 +17,23 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os, os.path, re, email.Utils
-from stgit.exception import *
-from stgit.utils import *
-from stgit.out import *
-from stgit.run import *
-from stgit import stack, git, basedir
-from stgit.config import config, file_extensions
+import email.utils
+import os
+import re
+import sys
+
+from stgit.exception import StgException
+from stgit.utils import (EditorException,
+                         add_sign_line,
+                         edit_string,
+                         get_hook,
+                         parse_name_email_date,
+                         run_hook_on_string,
+                         strip_prefix)
+from stgit.out import out
+from stgit.run import Run, RunException
+from stgit import stack, git
+from stgit.config import config
 from stgit.lib import stack as libstack
 from stgit.lib import git as libgit
 from stgit.lib import log
@@ -266,7 +276,7 @@ def parse_patches(patch_args, patch_list, boundary = 0, ordered = False):
     return patches
 
 def name_email(address):
-    p = email.Utils.parseaddr(address)
+    p = email.utils.parseaddr(address)
     if p[1]:
         return p
     else:
@@ -398,7 +408,7 @@ def parse_mail(msg):
     """Parse the message object and return (description, authname,
     authemail, authdate, diff)
     """
-    from email.Header import decode_header, make_header
+    from email.header import decode_header, make_header
 
     def __decode_header(header):
         """Decode a qp-encoded e-mail header as per rfc2047"""

--- a/stgit/commands/diff.py
+++ b/stgit/commands/diff.py
@@ -15,13 +15,14 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os
 from pydoc import pager
+
 from stgit.argparse import opt
-from stgit.commands.common import *
-from stgit.utils import *
-from stgit.out import *
-from stgit import argparse, stack, git
+from stgit.commands.common import (DirectoryHasRepository,
+                                   color_diff_flags,
+                                   git_id)
+from stgit.out import out
+from stgit import argparse, git
 from stgit.lib import git as gitlib
 
 help = 'Show the tree diff'

--- a/stgit/commands/edit.py
+++ b/stgit/commands/edit.py
@@ -118,10 +118,10 @@ def func(parser, options, args):
 
     def failed(reason='Edited patch did not apply.'):
         fn = '.stgit-failed.patch'
-        f = file(fn, 'w')
-        f.write(edit.patch_desc(stack.repository, cd,
-                                options.diff, options.diff_flags, failed_diff))
-        f.close()
+        with open(fn, 'w') as f:
+            f.write(edit.patch_desc(stack.repository, cd,
+                                    options.diff, options.diff_flags,
+                                    failed_diff))
         out.error(reason,
                   'The patch has been saved to "%s".' % fn)
         return utils.STGIT_COMMAND_ERROR

--- a/stgit/commands/edit.py
+++ b/stgit/commands/edit.py
@@ -18,10 +18,10 @@ along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
 from stgit.argparse import opt
-from stgit import argparse, git, utils
+from stgit import argparse, utils
 from stgit.commands import common
-from stgit.lib import git as gitlib, transaction, edit
-from stgit.out import *
+from stgit.lib import transaction, edit
+from stgit.out import out
 
 help = 'Edit a patch description or diff'
 kind = 'patch'

--- a/stgit/commands/export.py
+++ b/stgit/commands/export.py
@@ -1,5 +1,6 @@
 """Export command
 """
+from __future__ import print_function
 
 __copyright__ = """
 Copyright (C) 2005, Catalin Marinas <catalin.marinas@gmail.com>
@@ -116,7 +117,7 @@ def func(parser, options, args):
     # note the base commit for this series
     if not options.stdout:
         base_commit = stack.base.sha1
-        print >> series, '# This series applies on GIT commit %s' % base_commit
+        print('# This series applies on GIT commit %s' % base_commit, file=series)
 
     patch_no = 1
     for p in patches:
@@ -129,7 +130,7 @@ def func(parser, options, args):
             pname = '%s-%s' % (str(patch_no).zfill(zpadding), pname)
         pfile = os.path.join(dirname, pname)
         if not options.stdout:
-            print >> series, pname
+            print(pname, file=series)
 
         # get the patch description
         patch = stack.patches.get(p)
@@ -171,9 +172,9 @@ def func(parser, options, args):
             f = open(pfile, 'w+')
 
         if options.stdout and num > 1:
-            print '-'*79
-            print patch.name
-            print '-'*79
+            print('-'*79)
+            print(patch.name)
+            print('-'*79)
 
         f.write(descr)
         f.write(diff)

--- a/stgit/commands/export.py
+++ b/stgit/commands/export.py
@@ -87,7 +87,7 @@ def func(parser, options, args):
     if not options.stdout:
         if not os.path.isdir(dirname):
             os.makedirs(dirname)
-        series = file(os.path.join(dirname, 'series'), 'w+')
+        series = open(os.path.join(dirname, 'series'), 'w+')
 
     applied = stack.patchorder.applied
     unapplied = stack.patchorder.unapplied
@@ -106,7 +106,8 @@ def func(parser, options, args):
 
     # get the template
     if options.template:
-        tmpl = file(options.template).read()
+        with open(options.template) as f:
+            tmpl = f.read()
     else:
         tmpl = templates.get_template('patchexport.tmpl')
         if not tmpl:

--- a/stgit/commands/files.py
+++ b/stgit/commands/files.py
@@ -15,12 +15,10 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os
 from stgit.argparse import opt
-from stgit.commands.common import *
-from stgit.utils import *
-from stgit.out import *
-from stgit import argparse, stack, git
+from stgit.commands.common import DirectoryHasRepository, git_id
+from stgit.out import out
+from stgit import argparse, git
 from stgit.lib import git as gitlib
 
 help = 'Show the files modified by a patch (or the current patch)'

--- a/stgit/commands/float.py
+++ b/stgit/commands/float.py
@@ -55,7 +55,7 @@ def func(parser, options, args):
         if options.series == '-':
             f = sys.stdin
         else:
-            f = file(options.series)
+            f = open(options.series)
 
         patches = []
         for line in f:

--- a/stgit/commands/fold.py
+++ b/stgit/commands/fold.py
@@ -14,12 +14,17 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os
+import os
+
 from stgit.argparse import opt
-from stgit.commands.common import *
-from stgit.utils import *
-from stgit.out import *
-from stgit import argparse, stack, git
+from stgit.commands.common import (CmdException,
+                                   DirectoryHasRepository,
+                                   check_local_changes,
+                                   check_conflicts,
+                                   check_head_top_equal,
+                                   git_id)
+from stgit.out import out
+from stgit import argparse, git
 
 help = 'Integrate a GNU diff patch into the current patch'
 kind = 'patch'

--- a/stgit/commands/goto.py
+++ b/stgit/commands/goto.py
@@ -17,7 +17,6 @@ along with this program; if not, see http://www.gnu.org/licenses/.
 from stgit.commands import common
 from stgit.lib import transaction
 from stgit import argparse
-from stgit.argparse import opt
 
 help = 'Push or pop patches to the given one'
 kind = 'stack'

--- a/stgit/commands/id.py
+++ b/stgit/commands/id.py
@@ -16,7 +16,6 @@ along with this program; if not, see http://www.gnu.org/licenses/.
 
 from stgit.out import out
 from stgit.commands import common
-from stgit.lib import stack
 from stgit import argparse
 
 help = 'Print the git hash value of a StGit reference'

--- a/stgit/commands/imprt.py
+++ b/stgit/commands/imprt.py
@@ -14,14 +14,31 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os, re, email, tarfile
-from mailbox import UnixMailbox
 from StringIO import StringIO
+from mailbox import UnixMailbox
+import bz2
+import email
+import gzip
+import os
+import re
+import sys
+import tarfile
+
 from stgit.argparse import opt
-from stgit.commands.common import *
-from stgit.utils import *
-from stgit.out import *
-from stgit import argparse, stack, git
+from stgit.commands.common import (CmdException,
+                                   DirectoryHasRepository,
+                                   check_conflicts,
+                                   check_head_top_equal,
+                                   check_local_changes,
+                                   git_id,
+                                   name_email,
+                                   parse_mail,
+                                   parse_patch,
+                                   print_crt_patch)
+from stgit.utils import make_patch_name
+from stgit.config import config
+from stgit.out import out
+from stgit import argparse, git
 
 name = 'import'
 help = 'Import a GNU diff file as a new patch'
@@ -179,7 +196,6 @@ def __get_handle_and_name(filename):
     """Return a file object and a patch name derived from filename
     """
     # see if it's a gzip'ed or bzip2'ed patch
-    import bz2, gzip
     for copen, ext in [(gzip.open, '.gz'), (bz2.BZ2File, '.bz2')]:
         try:
             f = copen(filename)

--- a/stgit/commands/imprt.py
+++ b/stgit/commands/imprt.py
@@ -232,7 +232,7 @@ def __import_series(filename, options):
         if tarfile.is_tarfile(filename):
             __import_tarfile(filename, options)
             return
-        f = file(filename)
+        f = open(filename)
         patchdir = os.path.dirname(filename)
     else:
         f = sys.stdin
@@ -266,7 +266,7 @@ def __import_mbox(filename, options):
     """Import a series from an mbox file
     """
     if filename:
-        f = file(filename, 'rb')
+        f = open(filename, 'rb')
     else:
         f = StringIO(sys.stdin.read())
 

--- a/stgit/commands/imprt.py
+++ b/stgit/commands/imprt.py
@@ -302,15 +302,19 @@ def __import_mbox(filename, options):
 def __import_url(url, options):
     """Import a patch from a URL
     """
-    import urllib
+    try:
+        from urllib.request import urlretrieve
+        from urllib.parse import unquote
+    except ImportError:
+        from urllib import urlretrieve, unquote
     import tempfile
 
     if not url:
         raise CmdException('URL argument required')
 
-    patch = os.path.basename(urllib.unquote(url))
+    patch = os.path.basename(unquote(url))
     filename = os.path.join(tempfile.gettempdir(), patch)
-    urllib.urlretrieve(url, filename)
+    urlretrieve(url, filename)
     __import_file(filename, options)
 
 def __import_tarfile(tar, options):

--- a/stgit/commands/log.py
+++ b/stgit/commands/log.py
@@ -18,7 +18,6 @@ along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
 import os.path
-from optparse import make_option
 from stgit import argparse, run
 from stgit.argparse import opt
 from stgit.commands import common

--- a/stgit/commands/mail.py
+++ b/stgit/commands/mail.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 __copyright__ = """
 Copyright (C) 2005, Catalin Marinas <catalin.marinas@gmail.com>
 
@@ -258,7 +260,7 @@ def __send_message_smtp(smtpserver, from_addr, to_addr_list, msg, options):
 
         result = s.sendmail(from_addr, to_addr_list, msg)
         if len(result):
-            print "mail server refused delivery for the following recipients: %s" % result
+            print("mail server refused delivery for the following recipients: %s" % result)
     except Exception as err:
         raise CmdException(str(err))
 

--- a/stgit/commands/mail.py
+++ b/stgit/commands/mail.py
@@ -446,16 +446,14 @@ def __edit_message(msg):
     fname = '.stgitmail.txt'
 
     # create the initial file
-    f = file(fname, 'w')
-    f.write(msg)
-    f.close()
+    with open(fname, 'w') as f:
+        f.write(msg)
 
     call_editor(fname)
 
     # read the message back
-    f = file(fname)
-    msg = f.read()
-    f.close()
+    with open(fname) as f:
+        msg = f.read()
 
     return msg
 
@@ -711,7 +709,8 @@ def func(parser, options, args):
 
         # find the template file
         if options.cover:
-            tmpl = file(options.cover).read()
+            with open(options.cover) as f:
+                tmpl = f.read()
         else:
             tmpl = templates.get_template('covermail.tmpl')
             if not tmpl:
@@ -725,7 +724,8 @@ def func(parser, options, args):
 
     # send the patches
     if options.template:
-        tmpl = file(options.template).read()
+        with open(options.template) as f:
+            tmpl = f.read()
     else:
         if options.attach:
             tmpl = templates.get_template('mailattch.tmpl')

--- a/stgit/commands/mail.py
+++ b/stgit/commands/mail.py
@@ -14,12 +14,25 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os, re, time, datetime, socket, smtplib, getpass
-import email, email.Utils, email.Header
+import email
+import email.charset
+import email.header
+import email.utils
+import getpass
+import os
+import re
+import smtplib
+import socket
+import time
+
 from stgit.argparse import opt
-from stgit.commands.common import *
-from stgit.utils import *
-from stgit.out import *
+from stgit.commands.common import (CmdException,
+                                   DirectoryHasRepository,
+                                   address_or_alias,
+                                   git_id,
+                                   parse_patches)
+from stgit.utils import call_editor
+from stgit.out import out
 from stgit import argparse, stack, git, version, templates
 from stgit.config import config
 from stgit.run import Run
@@ -168,13 +181,13 @@ def __get_sender():
     if not sender:
         raise CmdException('Unknown sender name and e-mail; you should for '
                            'example set git config user.name and user.email')
-    sender = email.Utils.parseaddr(sender)
+    sender = email.utils.parseaddr(sender)
 
-    return email.Utils.formataddr(address_or_alias(sender))
+    return email.utils.formataddr(address_or_alias(sender))
 
 def __addr_list(msg, header):
     return [addr for name, addr in
-            email.Utils.getaddresses(msg.get_all(header, []))]
+            email.utils.getaddresses(msg.get_all(header, []))]
 
 def __parse_addresses(msg):
     """Return a two elements tuple: (from, [to])
@@ -293,7 +306,7 @@ def __send_message(type, tmpl, options, *args):
     if type == 'patch':
         (patch_nr, total_nr) = (args[1], args[2])
 
-    msg_id = email.Utils.make_msgid('stgit')
+    msg_id = email.utils.make_msgid('stgit')
     msg = build(tmpl, msg_id, options, *args)
 
     msg_str = msg.as_string(options.mbox)
@@ -324,7 +337,7 @@ def __send_message(type, tmpl, options, *args):
     return msg_id
 
 def __update_header(msg, header, addr = '', ignore = ()):
-    addr_pairs = email.Utils.getaddresses(msg.get_all(header, []) + [addr])
+    addr_pairs = email.utils.getaddresses(msg.get_all(header, []) + [addr])
     del msg[header]
     # remove pairs without an address and resolve the aliases
     addr_pairs = [address_or_alias(name_addr) for name_addr in addr_pairs
@@ -333,7 +346,7 @@ def __update_header(msg, header, addr = '', ignore = ()):
     addr_pairs = [name_addr for name_addr in addr_pairs
                   if name_addr[1] not in ignore]
     if addr_pairs:
-        msg[header] = ', '.join(map(email.Utils.formataddr, addr_pairs))
+        msg[header] = ', '.join(map(email.utils.formataddr, addr_pairs))
     return set(addr for _, addr in addr_pairs)
 
 def __build_address_headers(msg, options, extra_cc = []):
@@ -394,7 +407,7 @@ def __build_extra_headers(msg, msg_id, ref_id = None):
     """Build extra email headers and encoding
     """
     del msg['Date']
-    msg['Date'] = email.Utils.formatdate(localtime = True)
+    msg['Date'] = email.utils.formatdate(localtime = True)
     msg['Message-ID'] = msg_id
     if ref_id:
         # make sure the ref id has the angle brackets
@@ -411,7 +424,7 @@ def __build_extra_headers(msg, msg_id, ref_id = None):
 
 def __encode_message(msg):
     # 7 or 8 bit encoding
-    charset = email.Charset.Charset('utf-8')
+    charset = email.charset.Charset('utf-8')
     charset.body_encoding = None
 
     # encode headers
@@ -424,7 +437,7 @@ def __encode_message(msg):
                 # maybe we should try a different encoding or report
                 # the error. At the moment, we just ignore it
                 pass
-            words.append(email.Header.Header(uword).encode())
+            words.append(email.header.Header(uword).encode())
         new_val = ' '.join(words)
         msg.replace_header(header, new_val)
 
@@ -433,7 +446,7 @@ def __encode_message(msg):
     # some e-mail clients
     subject = msg.get('subject', '')
     msg.replace_header('subject',
-                       email.Header.Header(subject, header_name = 'subject'))
+                       email.header.Header(subject, header_name = 'subject'))
 
     # encode the body and set the MIME and encoding headers
     if msg.is_multipart():

--- a/stgit/commands/new.py
+++ b/stgit/commands/new.py
@@ -18,7 +18,6 @@ along with this program; if not, see http://www.gnu.org/licenses/.
 from stgit import argparse, utils
 from stgit.commands import common
 from stgit.lib import git as gitlib, transaction
-from stgit.config import config
 
 help = 'Create a new, empty patch'
 kind = 'patch'

--- a/stgit/commands/patches.py
+++ b/stgit/commands/patches.py
@@ -14,13 +14,12 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os
 from pydoc import pager
+
 from stgit.argparse import opt
-from stgit.commands.common import *
-from stgit.utils import *
-from stgit.out import *
-from stgit import argparse, stack, git
+from stgit.commands.common import CmdException, DirectoryHasRepository
+from stgit.out import out
+from stgit import argparse, git
 
 help = 'Show the applied patches modifying a file'
 kind = 'stack'

--- a/stgit/commands/pick.py
+++ b/stgit/commands/pick.py
@@ -14,12 +14,20 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os
 from stgit.argparse import opt
-from stgit.commands.common import *
-from stgit.utils import *
-from stgit.out import *
-from stgit import argparse, stack, git
+from stgit.commands.common import (CmdException,
+                                   DirectoryGotoToplevel,
+                                   check_head_top_equal,
+                                   check_local_changes,
+                                   check_conflicts,
+                                   git_id,
+                                   name_email_date,
+                                   parse_patches,
+                                   parse_rev,
+                                   print_crt_patch)
+from stgit.utils import find_patch_name
+from stgit.out import out
+from stgit import argparse, git
 from stgit.stack import Series
 
 help = 'Import a patch from a different branch or a commit object'

--- a/stgit/commands/publish.py
+++ b/stgit/commands/publish.py
@@ -17,8 +17,7 @@ along with this program; if not, see http://www.gnu.org/licenses/.
 from stgit import argparse
 from stgit.argparse import opt
 from stgit.commands import common
-from stgit.config import config
-from stgit.lib import git, stack, transaction
+from stgit.lib import git, transaction
 from stgit.out import out
 from stgit import utils
 

--- a/stgit/commands/publish.py
+++ b/stgit/commands/publish.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 __copyright__ = """
 Copyright (C) 2009, Catalin Marinas <catalin.marinas@gmail.com>
 
@@ -148,7 +150,7 @@ def func(parser, options, args):
         published = set(__get_published(stack, public_tree))
         for p in stack.patchorder.applied:
             if p not in published:
-                print p
+                print(p)
         return
 
     # check for rebased stack. In this case we emulate a merge with the stack

--- a/stgit/commands/pull.py
+++ b/stgit/commands/pull.py
@@ -14,13 +14,19 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os
 from stgit.argparse import opt
-from stgit.commands.common import *
-from stgit.utils import *
-from stgit.out import *
-from stgit.config import GitConfigException
-from stgit import argparse, stack, git
+from stgit.commands.common import (CmdException,
+                                   DirectoryGotoToplevel,
+                                   check_conflicts,
+                                   check_head_top_equal,
+                                   check_local_changes,
+                                   post_rebase,
+                                   prepare_rebase,
+                                   print_crt_patch,
+                                   rebase)
+from stgit.out import out
+from stgit.config import config, GitConfigException
+from stgit import argparse, git
 
 help = 'Pull changes from a remote repository'
 kind = 'stack'

--- a/stgit/commands/rebase.py
+++ b/stgit/commands/rebase.py
@@ -1,3 +1,17 @@
+from stgit.argparse import opt
+from stgit.commands.common import (CmdException,
+                                   DirectoryGotoToplevel,
+                                   check_conflicts,
+                                   check_head_top_equal,
+                                   check_local_changes,
+                                   git_id,
+                                   post_rebase,
+                                   prepare_rebase,
+                                   print_crt_patch,
+                                   rebase)
+from stgit import argparse
+from stgit.git import GitException
+
 __copyright__ = """
 Copyright (C) 2005, Catalin Marinas <catalin.marinas@gmail.com>
 
@@ -13,12 +27,6 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
-
-import sys, os
-from stgit.argparse import opt
-from stgit.commands.common import *
-from stgit.utils import *
-from stgit import argparse, stack, git
 
 help = 'Move the stack base to another point in history'
 kind = 'stack'

--- a/stgit/commands/rename.py
+++ b/stgit/commands/rename.py
@@ -14,12 +14,10 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os
 from stgit.argparse import opt
-from stgit.commands.common import *
-from stgit.utils import *
-from stgit.out import *
-from stgit import argparse, stack, git
+from stgit.commands.common import CmdException, DirectoryHasRepository
+from stgit.out import out
+from stgit import argparse
 
 help = 'Rename a patch'
 kind = 'patch'

--- a/stgit/commands/repair.py
+++ b/stgit/commands/repair.py
@@ -16,13 +16,15 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os
-from stgit.argparse import opt
-from stgit.commands.common import *
-from stgit.utils import *
-from stgit.out import *
-from stgit.run import *
-from stgit import stack, git
+import re
+
+from stgit.commands.common import (CmdException,
+                                   DirectoryGotoToplevel,
+                                   name_email_date)
+from stgit.utils import make_patch_name
+from stgit.out import out
+from stgit.run import Run
+from stgit import git
 
 help = 'Fix StGit metadata if branch was modified with git commands'
 kind = 'stack'

--- a/stgit/commands/repair.py
+++ b/stgit/commands/repair.py
@@ -208,11 +208,12 @@ def func(parser, options, args):
     for name in hidden_name_set - orig_hidden_name_set:
         out.info('%s is now hidden' % name)
     orig_order = dict(zip(orig_patches, xrange(len(orig_patches))))
-    def patchname_cmp(p1, p2):
-        i1 = orig_order.get(p1, len(orig_order))
-        i2 = orig_order.get(p2, len(orig_order))
-        return cmp((i1, p1), (i2, p2))
+
+    def patchname_key(p):
+        i = orig_order.get(p, len(orig_order))
+        return i, p
+
     crt_series.set_applied(p.patch for p in applied)
-    crt_series.set_unapplied(sorted(unapplied_name_set, cmp = patchname_cmp))
-    crt_series.set_hidden(sorted(hidden_name_set, cmp = patchname_cmp))
+    crt_series.set_unapplied(sorted(unapplied_name_set, key=patchname_key))
+    crt_series.set_hidden(sorted(hidden_name_set, key=patchname_key))
     out.done()

--- a/stgit/commands/reset.py
+++ b/stgit/commands/reset.py
@@ -18,8 +18,7 @@ along with this program; if not, see http://www.gnu.org/licenses/.
 
 from stgit.argparse import opt
 from stgit.commands import common
-from stgit.lib import git, log, transaction
-from stgit.out import out
+from stgit.lib import log, transaction
 from stgit import argparse, utils
 
 help = 'Reset the patch stack to an earlier state'

--- a/stgit/commands/show.py
+++ b/stgit/commands/show.py
@@ -14,10 +14,12 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os
 from pydoc import pager
 from stgit.argparse import opt
-from stgit.commands.common import *
+from stgit.commands.common import (DirectoryHasRepository,
+                                   color_diff_flags,
+                                   git_id,
+                                   parse_patches)
 from stgit import argparse, git
 from stgit.lib import git as gitlib
 

--- a/stgit/commands/squash.py
+++ b/stgit/commands/squash.py
@@ -17,7 +17,6 @@ along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
 from stgit.argparse import opt
-from stgit.out import *
 from stgit import argparse, utils
 from stgit.commands import common
 from stgit.lib import git, transaction

--- a/stgit/commands/sync.py
+++ b/stgit/commands/sync.py
@@ -14,12 +14,19 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os
-import stgit.commands.common
+import os
+import re
+
 from stgit.argparse import opt
-from stgit.commands.common import *
-from stgit.utils import *
-from stgit.out import *
+from stgit.commands.common import (CmdException,
+                                   DirectoryGotoToplevel,
+                                   check_local_changes,
+                                   check_conflicts,
+                                   check_head_top_equal,
+                                   parse_patches,
+                                   pop_patches,
+                                   push_patches)
+from stgit.out import out
 from stgit import argparse, stack, git
 
 help = 'Synchronise patches with a branch or a series'

--- a/stgit/commands/sync.py
+++ b/stgit/commands/sync.py
@@ -77,13 +77,12 @@ def func(parser, options, args):
         patchdir = os.path.dirname(options.series)
 
         remote_patches = []
-        f = file(options.series)
-        for line in f:
-            p = re.sub('#.*$', '', line).strip()
-            if not p:
-                continue
-            remote_patches.append(p)
-        f.close()
+        with open(options.series) as f:
+            for line in f:
+                p = re.sub('#.*$', '', line).strip()
+                if not p:
+                    continue
+                remote_patches.append(p)
 
         # the merge function merge_patch(patch, pname)
         merge_patch = lambda patch, pname: \

--- a/stgit/commands/uncommit.py
+++ b/stgit/commands/uncommit.py
@@ -19,7 +19,7 @@ along with this program; if not, see http://www.gnu.org/licenses/.
 from stgit.argparse import opt
 from stgit.commands import common
 from stgit.lib import transaction
-from stgit.out import *
+from stgit.out import out
 from stgit import argparse, utils
 
 help = 'Turn regular git commits into StGit patches'

--- a/stgit/commands/undo.py
+++ b/stgit/commands/undo.py
@@ -18,8 +18,7 @@ along with this program; if not, see http://www.gnu.org/licenses/.
 
 from stgit.argparse import opt
 from stgit.commands import common
-from stgit.lib import git, log, transaction
-from stgit.out import out
+from stgit.lib import log, transaction
 
 help = 'Undo the last operation'
 kind = 'stack'

--- a/stgit/completion.py
+++ b/stgit/completion.py
@@ -1,7 +1,7 @@
-import textwrap
+import itertools
+
 import stgit.commands
 from stgit import argparse
-import itertools
 
 def fun(name, *body):
     return ['%s ()' % name, '{', list(body), '}']

--- a/stgit/config.py
+++ b/stgit/config.py
@@ -17,10 +17,11 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import os, re
-from stgit import basedir
-from stgit.exception import *
-from stgit.run import *
+import os
+import re
+
+from stgit.exception import StgException
+from stgit.run import Run
 
 class GitConfigException(StgException):
     pass

--- a/stgit/git.py
+++ b/stgit/git.py
@@ -817,12 +817,10 @@ def apply_patch(filename = None, diff = None, base = None,
     """
     if diff is None:
         if filename:
-            f = file(filename)
+            with open(filename) as f:
+                diff = f.read()
         else:
-            f = sys.stdin
-        diff = f.read()
-        if filename:
-            f.close()
+            diff = sys.stdin.read()
 
     if base:
         orig_head = get_head()

--- a/stgit/git.py
+++ b/stgit/git.py
@@ -17,14 +17,15 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os, re
-from shutil import copyfile
+import os
+import re
+import sys
 
-from stgit.exception import *
+from stgit.exception import StgException
 from stgit import basedir
-from stgit.utils import *
-from stgit.out import *
-from stgit.run import *
+from stgit.utils import rename, strip_prefix
+from stgit.out import out
+from stgit.run import Run
 from stgit.config import config
 
 # git exception class

--- a/stgit/lib/git.py
+++ b/stgit/lib/git.py
@@ -1,8 +1,11 @@
 """A Python class hierarchy wrapping a git repository and its
 contents."""
 
-import atexit, os, os.path, re, signal
 from datetime import datetime, timedelta, tzinfo
+import atexit
+import os
+import re
+import signal
 
 from stgit import exception, run, utils
 from stgit.config import config

--- a/stgit/lib/git.py
+++ b/stgit/lib/git.py
@@ -793,13 +793,13 @@ class Repository(RunWithEnv):
                 ['-r', '-z'], t1.sha1, t2.sha1).split('\0'))
         try:
             while True:
-                x = i.next()
+                x = next(i)
                 if not x:
                     continue
                 omode, nmode, osha1, nsha1, status = x[1:].split(' ')
-                fn1 = i.next()
+                fn1 = next(i)
                 if status[0] in ['C', 'R']:
-                    fn2 = i.next()
+                    fn2 = next(i)
                 else:
                     fn2 = fn1
                 yield (omode, nmode, self.get_blob(osha1),

--- a/stgit/lib/log.py
+++ b/stgit/lib/log.py
@@ -165,8 +165,11 @@ class LogEntry(object):
             return self.patches[self.applied[-1]]
         else:
             return self.head
-    all_patches = property(lambda self: (self.applied + self.unapplied
-                                         + self.hidden))
+
+    @property
+    def all_patches(self):
+        return self.applied + self.unapplied + self.hidden
+
     @classmethod
     def from_stack(cls, prev, stack, message):
         return cls(

--- a/stgit/lib/log.py
+++ b/stgit/lib/log.py
@@ -99,12 +99,12 @@ The simplified log is exactly like the full log, except that its only
 parent is the (simplified) previous log entry, if any. It's purpose is
 mainly ease of visualization."""
 
+import StringIO
 import re
 from stgit.lib import git, stack as libstack
 from stgit import utils
 from stgit.exception import StgException, StackException
 from stgit.out import out
-import StringIO
 
 class LogException(StgException):
     pass

--- a/stgit/lib/stack.py
+++ b/stgit/lib/stack.py
@@ -13,7 +13,11 @@ class Patch(object):
     def __init__(self, stack, name):
         self.__stack = stack
         self.__name = name
-    name = property(lambda self: self.__name)
+
+    @property
+    def name(self):
+        return self.__name
+
     @property
     def __ref(self):
         return 'refs/patches/%s/%s' % (self.__stack.name, self.__name)
@@ -119,14 +123,38 @@ class PatchOrder(object):
         if val != self.__lists.get(name, None):
             self.__lists[name] = val
             self.__write_file(name, val)
-    applied = property(lambda self: self.__get_list('applied'),
-                       lambda self, val: self.__set_list('applied', val))
-    unapplied = property(lambda self: self.__get_list('unapplied'),
-                         lambda self, val: self.__set_list('unapplied', val))
-    hidden = property(lambda self: self.__get_list('hidden'),
-                      lambda self, val: self.__set_list('hidden', val))
-    all = property(lambda self: self.applied + self.unapplied + self.hidden)
-    all_visible = property(lambda self: self.applied + self.unapplied)
+
+    @property
+    def applied(self):
+        return self.__get_list('applied')
+
+    @applied.setter
+    def applied(self, value):
+        self.__set_list('applied', value)
+
+    @property
+    def unapplied(self):
+        return self.__get_list('unapplied')
+
+    @unapplied.setter
+    def unapplied(self, value):
+        self.__set_list('unapplied', value)
+
+    @property
+    def hidden(self):
+        return self.__get_list('hidden')
+
+    @hidden.setter
+    def hidden(self, value):
+        self.__set_list('hidden', value)
+
+    @property
+    def all(self):
+        return self.applied + self.unapplied + self.hidden
+
+    @property
+    def all_visible(self):
+        return self.applied + self.unapplied
 
     @staticmethod
     def create(stackdir):
@@ -172,8 +200,15 @@ class Stack(git.Branch):
         self.__patches = Patches(self)
         if not stackupgrade.update_to_current_format_version(repository, name):
             raise StackException('%s: branch not initialized' % name)
-    patchorder = property(lambda self: self.__patchorder)
-    patches = property(lambda self: self.__patches)
+
+    @property
+    def patchorder(self):
+        return self.__patchorder
+
+    @property
+    def patches(self):
+        return self.__patches
+
     @property
     def directory(self):
         return os.path.join(self.repository.directory, self.__repo_subdir, self.name)

--- a/stgit/lib/stackupgrade.py
+++ b/stgit/lib/stackupgrade.py
@@ -64,8 +64,11 @@ def update_to_current_format_version(repository, branch):
         patch_dir = os.path.join(branch_dir, 'patches')
         mkdir(patch_dir)
         refs_base = 'refs/patches/%s' % branch
-        for patch in (file(os.path.join(branch_dir, 'unapplied')).readlines()
-                      + file(os.path.join(branch_dir, 'applied')).readlines()):
+        with open(os.path.join(branch_dir, 'unapplied')) as f:
+            patches = f.readlines()
+        with open(os.path.join(branch_dir, 'applied')) as f:
+            patches.extend(f.readlines())
+        for patch in patches:
             patch = patch.strip()
             os.rename(os.path.join(branch_dir, patch),
                       os.path.join(patch_dir, patch))

--- a/stgit/lib/transaction.py
+++ b/stgit/lib/transaction.py
@@ -5,7 +5,6 @@ import atexit
 import itertools as it
 
 from stgit import exception, utils
-from stgit.utils import any
 from stgit.out import *
 from stgit.lib import git, log
 from stgit.config import config

--- a/stgit/lib/transaction.py
+++ b/stgit/lib/transaction.py
@@ -104,44 +104,78 @@ class StackTransaction(object):
             self.__assert_head_top_equal()
         if check_clean_iw:
             self.__assert_index_worktree_clean(check_clean_iw)
-    stack = property(lambda self: self.__stack)
-    patches = property(lambda self: self.__patches)
-    def __set_applied(self, val):
-        self.__applied = list(val)
-    applied = property(lambda self: self.__applied, __set_applied)
-    def __set_unapplied(self, val):
-        self.__unapplied = list(val)
-    unapplied = property(lambda self: self.__unapplied, __set_unapplied)
-    def __set_hidden(self, val):
-        self.__hidden = list(val)
-    hidden = property(lambda self: self.__hidden, __set_hidden)
-    all_patches = property(lambda self: (self.__applied + self.__unapplied
-                                         + self.__hidden))
-    def __set_base(self, val):
+
+    @property
+    def stack(self):
+        return self.__stack
+
+    @property
+    def patches(self):
+        return self.__patches
+
+    @property
+    def applied(self):
+        return self.__applied
+
+    @applied.setter
+    def applied(self, value):
+        self.__applied = list(value)
+
+    @property
+    def unapplied(self):
+        return self.__unapplied
+
+    @unapplied.setter
+    def unapplied(self, value):
+        self.__unapplied = list(value)
+
+    @property
+    def hidden(self):
+        return self.__hidden
+
+    @hidden.setter
+    def hidden(self, value):
+        self.__hidden = list(value)
+
+    @property
+    def all_patches(self):
+        return self.__applied + self.__unapplied + self.__hidden
+
+    @property
+    def base(self):
+        return self.__base
+
+    @base.setter
+    def base(self, value):
         assert (not self.__applied
-                or self.patches[self.applied[0]].data.parent == val)
-        self.__base = val
-    base = property(lambda self: self.__base, __set_base)
+                or self.patches[self.applied[0]].data.parent == value)
+        self.__base = value
+
     @property
     def temp_index(self):
         if not self.__temp_index:
             self.__temp_index = self.__stack.repository.temp_index()
             atexit.register(self.__temp_index.delete)
         return self.__temp_index
+
     @property
     def top(self):
         if self.__applied:
             return self.__patches[self.__applied[-1]]
         else:
             return self.__base
-    def __get_head(self):
+
+    @property
+    def head(self):
         if self.__bad_head:
             return self.__bad_head
         else:
             return self.top
-    def __set_head(self, val):
-        self.__bad_head = val
-    head = property(__get_head, __set_head)
+
+    @head.setter
+    def head(self, value):
+        self.__bad_head = value
+
     def __assert_head_top_equal(self):
         if not self.__stack.head_top_equal():
             out.error(

--- a/stgit/lib/transaction.py
+++ b/stgit/lib/transaction.py
@@ -5,7 +5,7 @@ import atexit
 import itertools as it
 
 from stgit import exception, utils
-from stgit.out import *
+from stgit.out import out
 from stgit.lib import git, log
 from stgit.config import config
 

--- a/stgit/main.py
+++ b/stgit/main.py
@@ -17,10 +17,12 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os, traceback
+import os
+import sys
+import traceback
 
 import stgit.commands
-from stgit.out import *
+from stgit.out import out
 from stgit import argparse, run, utils
 from stgit.config import config
 

--- a/stgit/main.py
+++ b/stgit/main.py
@@ -1,5 +1,6 @@
 """Basic quilt-like functionality
 """
+from __future__ import print_function
 
 __copyright__ = """
 Copyright (C) 2005, Catalin Marinas <catalin.marinas@gmail.com>
@@ -85,13 +86,13 @@ commands = Commands((cmd, mod) for cmd, (mod, kind, help)
                     in cmd_list.iteritems())
 
 def print_help():
-    print 'usage: %s <command> [options]' % os.path.basename(sys.argv[0])
-    print
-    print 'Generic commands:'
-    print '  help        print the detailed command usage'
-    print '  version     display version information'
-    print '  copyright   display copyright information'
-    print
+    print('usage: %s <command> [options]' % os.path.basename(sys.argv[0]))
+    print()
+    print('Generic commands:')
+    print('  help        print the detailed command usage')
+    print('  version     display version information')
+    print('  copyright   display copyright information')
+    print()
     stgit.commands.pretty_command_list(cmd_list, sys.stdout)
 
 #
@@ -105,9 +106,8 @@ def _main():
     prog = os.path.basename(sys.argv[0])
 
     if len(sys.argv) < 2:
-        print >> sys.stderr, 'usage: %s <command>' % prog
-        print >> sys.stderr, \
-              '  Try "%s --help" for a list of supported commands' % prog
+        print('usage: %s <command>' % prog, file=sys.stderr)
+        print('  Try "%s --help" for a list of supported commands' % prog, file=sys.stderr)
         sys.exit(utils.STGIT_GENERAL_ERROR)
 
     cmd = sys.argv[1]
@@ -138,12 +138,12 @@ def _main():
         sys.exit(utils.STGIT_SUCCESS)
     if cmd in ['-v', '--version', 'version']:
         from stgit.version import version
-        print 'Stacked GIT %s' % version
+        print('Stacked GIT %s' % version)
         os.system('git --version')
-        print 'Python version %s' % sys.version
+        print('Python version %s' % sys.version)
         sys.exit(utils.STGIT_SUCCESS)
     if cmd in ['copyright']:
-        print __copyright__
+        print(__copyright__)
         sys.exit(utils.STGIT_SUCCESS)
 
     # re-build the command line arguments

--- a/stgit/main.py
+++ b/stgit/main.py
@@ -160,9 +160,12 @@ def _main():
 
     # These modules are only used from this point onwards and do not
     # need to be imported earlier
+    try:
+        from configparser import ParsingError, NoSectionError
+    except ImportError:
+        from ConfigParser import ParsingError, NoSectionError
     from stgit.exception import StgException
     from stgit.config import config_setup
-    from ConfigParser import ParsingError, NoSectionError
     from stgit.stack import Series
 
     try:

--- a/stgit/out.py
+++ b/stgit/out.py
@@ -16,7 +16,8 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, textwrap
+import sys
+import textwrap
 
 class MessagePrinter(object):
     def __init__(self, file = None):

--- a/stgit/run.py
+++ b/stgit/run.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import division
 
 __copyright__ = """
 Copyright (C) 2007, Karl Hasselström <kha@treskal.com>

--- a/stgit/run.py
+++ b/stgit/run.py
@@ -109,11 +109,7 @@ class Run(object):
                                  stdin = subprocess.PIPE,
                                  stdout = subprocess.PIPE,
                                  stderr = subprocess.PIPE)
-            # TODO: only use communicate() once support for Python 2.4 is
-            # dropped (write() needed because of performance reasons)
-            if self.__indata:
-                p.stdin.write(self.__indata)
-            outdata, errdata = p.communicate()
+            outdata, errdata = p.communicate(self.__indata)
             self.exitcode = p.returncode
         except OSError as e:
             raise self.exc('%s failed: %s' % (self.__cmd[0], e))

--- a/stgit/run.py
+++ b/stgit/run.py
@@ -16,10 +16,12 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import datetime, os, subprocess
+import datetime
+import os
+import subprocess
 
-from stgit.exception import *
-from stgit.out import *
+from stgit.exception import StgException
+from stgit.out import out, MessagePrinter
 
 class RunException(StgException):
     """Thrown when something bad happened when we tried to run the

--- a/stgit/stack.py
+++ b/stgit/stack.py
@@ -1,5 +1,6 @@
 """Basic quilt-like functionality
 """
+from __future__ import print_function
 
 __copyright__ = """
 Copyright (C) 2005, Catalin Marinas <catalin.marinas@gmail.com>
@@ -85,26 +86,26 @@ def edit_file(series, line, comment, show_patch = True):
 
     with open(fname, 'w+') as f:
         if line:
-            print >> f, line
+            print(line, file=f)
         elif tmpl:
-            print >> f, tmpl,
+            print(tmpl, end=' ', file=f)
         else:
-            print >> f
-        print >> f, __comment_prefix, comment
-        print >> f, __comment_prefix, \
-              'Lines prefixed with "%s" will be automatically removed.' \
-              % __comment_prefix
-        print >> f, __comment_prefix, \
-              'Trailing empty lines will be automatically removed.'
+            print(file=f)
+        print(__comment_prefix, comment, file=f)
+        print(__comment_prefix,
+              'Lines prefixed with "%s" will be automatically removed.'
+              % __comment_prefix, file=f)
+        print(__comment_prefix,
+              'Trailing empty lines will be automatically removed.', file=f)
 
         if show_patch:
-           print >> f, __patch_prefix
+           print(__patch_prefix, file=f)
            # series.get_patch(series.get_current()).get_top()
            diff_str = git.diff(rev1 = series.get_patch(series.get_current()).get_bottom())
            f.write(diff_str)
 
         #Vim modeline must be near the end.
-        print >> f, __comment_prefix, 'vi: set textwidth=75 filetype=diff nobackup:'
+        print(__comment_prefix, 'vi: set textwidth=75 filetype=diff nobackup:', file=f)
 
     call_editor(fname)
 

--- a/stgit/stack.py
+++ b/stgit/stack.py
@@ -17,16 +17,27 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os, re
-from email.Utils import formatdate
+import os
+import re
+from email.utils import formatdate
 
 from stgit.exception import StackException
-from stgit.utils import *
-from stgit.out import *
-from stgit.run import *
+from stgit.utils import (add_sign_line,
+                         append_string,
+                         append_strings,
+                         call_editor,
+                         create_empty_file,
+                         insert_string,
+                         make_patch_name,
+                         read_string,
+                         read_strings,
+                         rename,
+                         write_string,
+                         write_strings)
+from stgit.out import out
+from stgit.run import Run
 from stgit import git, basedir, templates
 from stgit.config import config
-from shutil import copyfile
 from stgit.lib import git as libgit, stackupgrade
 
 

--- a/stgit/templates.py
+++ b/stgit/templates.py
@@ -17,7 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, see http://www.gnu.org/licenses/.
 """
 
-import sys, os
+import os
+import sys
 
 from stgit import basedir
 

--- a/stgit/templates.py
+++ b/stgit/templates.py
@@ -32,10 +32,9 @@ def get_template(tfile):
                   os.path.join(sys.prefix, 'share', 'stgit', 'templates',
                                tfile) ]
 
-    tmpl = None
     for t in tmpl_list:
         if os.path.isfile(t):
-            tmpl = file(t).read()
-            break
-
-    return tmpl
+            with open(t) as f:
+                return f.read()
+    else:
+        return None

--- a/stgit/utils.py
+++ b/stgit/utils.py
@@ -1,10 +1,14 @@
 """Common utility functions
 """
 
-import errno, os, os.path, re, sys, tempfile
-from stgit.exception import *
+import errno
+import os
+import re
+import tempfile
+
+from stgit.exception import StgException
 from stgit.config import config
-from stgit.out import *
+from stgit.out import out
 
 __copyright__ = """
 Copyright (C) 2005, Catalin Marinas <catalin.marinas@gmail.com>

--- a/stgit/utils.py
+++ b/stgit/utils.py
@@ -1,6 +1,6 @@
 """Common utility functions
 """
-
+from __future__ import print_function
 import errno
 import os
 import re
@@ -57,23 +57,22 @@ def write_string(filename, line, multiline = False):
     """Writes 'line' to file and truncates it
     """
     with mkdir_file(filename, 'w+') as f:
-        if multiline:
-            f.write(line)
-        else:
-            print >> f, line
+        print(line,
+              end='' if multiline else '\n',
+              file=f)
 
 def append_strings(filename, lines):
     """Appends 'lines' sequence to file
     """
     with mkdir_file(filename, 'a+') as f:
         for line in lines:
-            print >> f, line
+            print(line, file=f)
 
 def append_string(filename, line):
     """Appends 'line' to file
     """
     with mkdir_file(filename, 'a+') as f:
-        print >> f, line
+        print(line, file=f)
 
 def insert_string(filename, line):
     """Inserts 'line' at the beginning of the file
@@ -82,7 +81,7 @@ def insert_string(filename, line):
         lines = f.readlines()
         f.seek(0)
         f.truncate()
-        print >> f, line
+        print(line, file=f)
         f.writelines(lines)
 
 def create_empty_file(name):

--- a/stgit/utils.py
+++ b/stgit/utils.py
@@ -26,69 +26,60 @@ def mkdir_file(filename, mode):
     """Opens filename with the given mode, creating the directory it's
     in if it doesn't already exist."""
     create_dirs(os.path.dirname(filename))
-    return file(filename, mode)
+    return open(filename, mode)
 
 def read_strings(filename):
     """Reads the lines from a file
     """
-    f = file(filename, 'r')
-    lines = [line.strip() for line in f.readlines()]
-    f.close()
-    return lines
+    with open(filename) as f:
+        return [line.strip() for line in f.readlines()]
 
 def read_string(filename, multiline = False):
     """Reads the first line from a file
     """
-    f = file(filename, 'r')
-    if multiline:
-        result = f.read()
-    else:
-        result = f.readline().strip()
-    f.close()
-    return result
+    with open(filename) as f:
+        if multiline:
+            return f.read()
+        else:
+            return f.readline().strip()
 
 def write_strings(filename, lines):
     """Write 'lines' sequence to file
     """
-    f = file(filename, 'w+')
-    f.writelines([line + '\n' for line in lines])
-    f.close()
+    with open(filename, 'w+') as f:
+        f.writelines([line + '\n' for line in lines])
 
 def write_string(filename, line, multiline = False):
     """Writes 'line' to file and truncates it
     """
-    f = mkdir_file(filename, 'w+')
-    if multiline:
-        f.write(line)
-    else:
-        print >> f, line
-    f.close()
+    with mkdir_file(filename, 'w+') as f:
+        if multiline:
+            f.write(line)
+        else:
+            print >> f, line
 
 def append_strings(filename, lines):
     """Appends 'lines' sequence to file
     """
-    f = mkdir_file(filename, 'a+')
-    for line in lines:
-        print >> f, line
-    f.close()
+    with mkdir_file(filename, 'a+') as f:
+        for line in lines:
+            print >> f, line
 
 def append_string(filename, line):
     """Appends 'line' to file
     """
-    f = mkdir_file(filename, 'a+')
-    print >> f, line
-    f.close()
+    with mkdir_file(filename, 'a+') as f:
+        print >> f, line
 
 def insert_string(filename, line):
     """Inserts 'line' at the beginning of the file
     """
-    f = mkdir_file(filename, 'r+')
-    lines = f.readlines()
-    f.seek(0)
-    f.truncate()
-    print >> f, line
-    f.writelines(lines)
-    f.close()
+    with mkdir_file(filename, 'r+') as f:
+        lines = f.readlines()
+        f.seek(0)
+        f.truncate()
+        print >> f, line
+        f.writelines(lines)
 
 def create_empty_file(name):
     """Creates an empty file
@@ -237,13 +228,11 @@ def run_hook_on_string(hook, s, *args):
     return s
 
 def edit_string(s, filename):
-    f = file(filename, 'w')
-    f.write(s)
-    f.close()
+    with open(filename, 'w') as f:
+        f.write(s)
     call_editor(filename)
-    f = file(filename)
-    s = f.read()
-    f.close()
+    with open(filename) as f:
+        s = f.read()
     os.remove(filename)
     return s
 

--- a/stgit/utils.py
+++ b/stgit/utils.py
@@ -298,25 +298,6 @@ def make_patch_name(msg, unacceptable, default_name = 'patch'):
         patchname = default_name
     return find_patch_name(patchname, unacceptable)
 
-# any and all functions are builtin in Python 2.5 and higher, but not
-# in 2.4.
-if 'any' in dir(__builtins__):
-    any = getattr(__builtins__, 'any')
-else:
-    def any(bools):
-        for b in bools:
-            if b:
-                return True
-        return False
-
-if 'all' in dir(__builtins__):
-    all = getattr(__builtins__, 'all')
-else:
-    def all(bools):
-        for b in bools:
-            if not b:
-                return False
-        return True
 
 def add_sign_line(desc, sign_str, name, email):
     if not sign_str:

--- a/stgit/version.py
+++ b/stgit/version.py
@@ -1,6 +1,9 @@
+import os
+import re
+import sys
+
 from stgit.exception import StgException
 from stgit import run, utils
-import os, os.path, re, sys
 
 class VersionUnavailable(StgException):
     pass

--- a/stgit/version.py
+++ b/stgit/version.py
@@ -39,8 +39,9 @@ def write_builtin_version():
         v = git_describe_version()
     except VersionUnavailable:
         return
-    f = file(_builtin_version_file(), 'w')
-    f.write('# This file was generated automatically. Do not edit by hand.\n'
+    with open(_builtin_version_file(), 'w') as f:
+        f.write(
+            '# This file was generated automatically. Do not edit by hand.\n'
             'version = %r\n' % v)
 
 def get_version():

--- a/stgit/version.py
+++ b/stgit/version.py
@@ -55,4 +55,4 @@ version = get_version()
 
 # minimum version requirements
 git_min_ver = '1.5.2'
-python_min_ver = '2.4'
+python_min_ver = '2.6'

--- a/t/test.py
+++ b/t/test.py
@@ -1,5 +1,5 @@
 # Run the test suite in parallel.
-
+from __future__ import print_function
 import glob
 import math
 import optparse
@@ -165,7 +165,7 @@ def main():
         tests = glob.glob("t[0-9][0-9][0-9][0-9]-*.sh")
     if opts.jobs is None:
         opts.jobs = default_num_jobs()
-    print "Running %d tests in parallel" % opts.jobs
+    print("Running %d tests in parallel" % opts.jobs)
 
     if os.path.exists("trash"):
         os.rename("trash", "trash-being-deleted-%016x" % random.getrandbits(64))
@@ -178,10 +178,10 @@ def main():
         start_cleaner(q)
     failed = q.wait()
     if failed:
-        print "Failed:"
+        print("Failed:")
         for t in sorted(failed):
-            print "  ", t
-        print "Done"
+            print("  ", t)
+        print("Done")
         return 1
     else:
         return 0

--- a/t/test.py
+++ b/t/test.py
@@ -1,7 +1,6 @@
 # Run the test suite in parallel.
 
 import glob
-import itertools as it
 import math
 import optparse
 import os
@@ -11,7 +10,6 @@ import shutil
 import subprocess
 import sys
 import threading
-import time
 import traceback
 
 # Number of jobs to run in parallel.

--- a/t/test.py
+++ b/t/test.py
@@ -70,97 +70,75 @@ class TestQueue(object):
 
     # Yield free jobs until none are left.
     def next(self):
-        self.lock.acquire()
-        try:
+        with self.lock:
             if not self.__remaining:
                 raise StopIteration
             t = self.__remaining.pop()
             self.__running.add(t)
             self.__report()
             return t
-        finally:
-            self.lock.release()
 
     # Report that a job has completed.
     def finished(self, t, success):
-        self.lock.acquire()
-        try:
+        with self.lock:
             self.__running.remove(t)
             if success:
                 self.__success.add(t)
             else:
                 self.__fail.add(t)
             self.__report()
-        finally:
-            self.lock.release()
 
     # Yield free cleaning jobs until none are left.
     def cleaning_jobs(self):
         while True:
-            self.lock.acquire()
-            try:
+            with self.lock:
                 if not self.__clean_todo:
                     return
                 c = self.__clean_todo.pop()
                 self.__clean_running.add(c)
-            finally:
-                self.lock.release()
             yield c
 
     # Report that a cleaning job has completed.
     def deleted(self, c):
-        self.lock.acquire()
-        try:
+        with self.lock:
             self.__clean_running.remove(c)
             self.__clean_done.add(c)
             self.__report()
-        finally:
-            self.lock.release()
 
     # Wait for all jobs to complete.
     def wait(self):
-        self.lock.acquire()
-        try:
+        with self.lock:
             while not self.__done():
                 self.__cv.wait()
             for c in self.__clean_jobs:
                 os.rmdir(c)
             return set(self.__fail)
-        finally:
-            self.lock.release()
 
 def start_worker(q):
     def w():
         for t in q:
             try:
-                try:
-                    ok = False  # assume the worst until proven otherwise
-                    s = os.path.join("trash", t)
-                    e = dict(os.environ)
-                    e["SCRATCHDIR"] = s
-                    p = subprocess.Popen([os.path.join(os.getcwd(), t), "-v"],
-                                         stdout=subprocess.PIPE,
-                                         stderr=subprocess.STDOUT,
-                                         env=e)
-                    (out, err) = p.communicate()
-                    assert err is None
-                    f = open(os.path.join(s, "output"), "w")
-                    try:
-                        f.write(out)
-                        f.write("\nExited with code %d\n" % p.returncode)
-                    finally:
-                        f.close()
-                    if p.returncode == 0:
-                        ok = True
-                except:
-                    # Log the traceback. Use the mutex so that we
-                    # won't write multiple tracebacks to stderr at the
-                    # same time.
-                    q.lock.acquire()
-                    try:
-                        traceback.print_exc()
-                    finally:
-                        q.lock.release()
+                ok = False  # assume the worst until proven otherwise
+                s = os.path.join("trash", t)
+                e = dict(os.environ)
+                e["SCRATCHDIR"] = s
+                p = subprocess.Popen([os.path.join(os.getcwd(), t), "-v"],
+                                     stdout=subprocess.PIPE,
+                                     stderr=subprocess.STDOUT,
+                                     env=e)
+                (out, err) = p.communicate()
+                assert err is None
+                with open(os.path.join(s, "output"), "w") as f:
+                    f.write(out)
+                    f.write("\nExited with code %d\n" % p.returncode)
+                if p.returncode == 0:
+                    ok = True
+            except:
+                # Log the traceback. Use the mutex so that we
+                # won't write multiple tracebacks to stderr at the
+                # same time.
+                with q.lock:
+                    traceback.print_exc()
             finally:
                 q.finished(t, ok)
     threading.Thread(target=w).start()

--- a/t/test.py
+++ b/t/test.py
@@ -68,7 +68,7 @@ class TestQueue(object):
         sys.stdout.flush()
 
     # Yield free jobs until none are left.
-    def next(self):
+    def __next__(self):
         with self.lock:
             if not self.__remaining:
                 raise StopIteration
@@ -76,6 +76,8 @@ class TestQueue(object):
             self.__running.add(t)
             self.__report()
             return t
+
+    next = __next__
 
     # Report that a job has completed.
     def finished(self, t, success):

--- a/t/test.py
+++ b/t/test.py
@@ -56,15 +56,16 @@ class TestQueue(object):
         cd = len(self.__clean_done) + 1e-3  # clever way to avoid div by zero
         cr = len(self.__clean_running)
         ct = len(self.__clean_todo)
-        sys.stdout.write(("\rQueue: %3d,  Running: %3d,  OK: %3d,"
-                          "  Failed: %3d,  Cleanup: %3d%%")
-                         % (len(self.__remaining), len(self.__running),
-                            len(self.__success), len(self.__fail),
-                            math.floor(100.0 * cd / (cd + cr + ct))))
-        sys.stdout.flush()
+        print("\rQueue: %3d," % len(self.__remaining),
+              "Running: %3d," % len(self.__running),
+              "OK: %3d," % len(self.__success),
+              "Failed: %3d," % len(self.__fail),
+              "Cleanup: %3d%%" % math.floor(100.0 * cd / (cd + cr + ct)),
+              sep="  ", end='', file=sys.stdout)
         if self.__done():
-            sys.stdout.write("\n")
+            print(file=sys.stdout)
             self.__cv.notifyAll()
+        sys.stdout.flush()
 
     # Yield free jobs until none are left.
     def next(self):
@@ -127,8 +128,8 @@ def start_worker(q):
                 (out, err) = p.communicate()
                 assert err is None
                 with open(os.path.join(s, "output"), "w") as f:
-                    f.write(out)
-                    f.write("\nExited with code %d\n" % p.returncode)
+                    print(out, file=f)
+                    print("Exited with code %d" % p.returncode, file=f)
                 if p.returncode == 0:
                     ok = True
             except:

--- a/t/test.py
+++ b/t/test.py
@@ -1,5 +1,5 @@
 # Run the test suite in parallel.
-from __future__ import print_function
+from __future__ import division, print_function
 import glob
 import math
 import optparse
@@ -60,7 +60,7 @@ class TestQueue(object):
               "Running: %3d," % len(self.__running),
               "OK: %3d," % len(self.__success),
               "Failed: %3d," % len(self.__fail),
-              "Cleanup: %3d%%" % math.floor(100.0 * cd / (cd + cr + ct)),
+              "Cleanup: %3d%%" % math.floor(100 * cd / (cd + cr + ct)),
               sep="  ", end='', file=sys.stdout)
         if self.__done():
             print(file=sys.stdout)
@@ -175,7 +175,7 @@ def main():
     w = min(opts.jobs, len(tests))
     for i in range(w):
         start_worker(q)
-    for i in range(max(w / 4, 1)):
+    for i in range(max(w // 4, 1)):
         start_cleaner(q)
     failed = q.wait()
     if failed:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py24,py25,py26,py27,pypy
+envlist = py26,py27,pypy
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
This patch series takes a few more aggressive steps toward Python 3 compatibility. These changes necessarily break compatibility with Python 2.4 and 2.5 thus making the new minimum version Python 2.6.

The ultimate goal is to support Python 3.4+ and Python 2.7 out of the same codebase.