### PR TITLE
refresh: do not include submodules by default

### DIFF
--- a/stgit/commands/pull.py
+++ b/stgit/commands/pull.py
@@ -114,7 +114,7 @@ def func(parser, options, args):
     post_rebase(crt_series, applied, options.nopush, options.merged)
 
     # maybe tidy up
-    if config.get('stgit.keepoptimized') == 'yes':
+    if config.getbool('stgit.keepoptimized'):
         git.repack()
 
     print_crt_patch(crt_series)

--- a/stgit/commands/refresh.py
+++ b/stgit/commands/refresh.py
@@ -6,6 +6,7 @@ from stgit import argparse, utils
 from stgit.argparse import opt
 from stgit.commands import common
 from stgit.lib import git, transaction, edit
+from stgit.config import config, GitConfigException
 from stgit.out import out
 
 __copyright__ = """
@@ -71,7 +72,11 @@ options = [
     opt('-e', '--edit', action = 'store_true',
         short = 'Invoke an editor for the patch description'),
     opt('-a', '--annotate', metavar = 'NOTE',
-        short = 'Annotate the patch log entry')
+        short = 'Annotate the patch log entry'),
+    opt('-s', '--submodules', action = 'store_true',
+        short = 'Include submodules when refreshing patch contents'),
+    opt('', '--no-submodules', action = 'store_false', dest = 'submodules',
+        short = 'Exclude submodules when refreshing patch contents')
     ] + (argparse.message_options(save_template = False) +
          argparse.hook_options() +
          argparse.sign_options() + argparse.author_options())
@@ -91,7 +96,7 @@ def get_patch(stack, given_patch):
                 'Cannot refresh top patch, because no patches are applied')
         return stack.patchorder.applied[-1]
 
-def list_files(stack, patch_name, args, index, update):
+def list_files(stack, patch_name, args, index, update, submodules):
     """Figure out which files to update."""
     if index:
         # --index: Don't update the index.
@@ -102,6 +107,15 @@ def list_files(stack, patch_name, args, index, update):
         # --update: Restrict update to the paths that were already
         # part of the patch.
         paths &= stack.patches.get(patch_name).files()
+    else:
+        # Avoid including submodule files by default. This is to ensure that
+        # users in repositories with submodueles do not accidentally include
+        # submodule changes to patches just because they happen to have not
+        # run "git submodule update" prior to running stg refresh. We won't
+        # exclude them if we're explicitly told to include them, or if we're
+        # given explicit paths.
+        if not args and not submodules:
+            paths -= stack.repository.submodules(stack.head.data.tree)
     return paths
 
 def write_tree(stack, paths, temp_index):
@@ -245,9 +259,22 @@ def func(parser, options, args):
         raise common.CmdException(
             'You cannot --force a full refresh when using --index mode')
 
+    if options.update and options.submodules:
+        raise common.CmdException(
+            '--submodules is meaningless when only updating modified files')
+
+    if options.index and options.submodules:
+        raise common.CmdException(
+            '--submodules is meaningless when keeping the current index')
+
+    # If submodules was not specified on the command line, infer a default
+    # from configuration.
+    if options.submodules is None:
+        options.submodules = (config.get('stgit.refreshsubmodules') == 'yes')
+
     stack = directory.repository.current_stack
     patch_name = get_patch(stack, options.patch)
-    paths = list_files(stack, patch_name, args, options.index, options.update)
+    paths = list_files(stack, patch_name, args, options.index, options.update, options.submodules)
 
     # Make sure there are no conflicts in the files we want to
     # refresh.

--- a/stgit/commands/refresh.py
+++ b/stgit/commands/refresh.py
@@ -270,7 +270,7 @@ def func(parser, options, args):
     # If submodules was not specified on the command line, infer a default
     # from configuration.
     if options.submodules is None:
-        options.submodules = (config.get('stgit.refreshsubmodules') == 'yes')
+        options.submodules = (config.getbool('stgit.refreshsubmodules'))
 
     stack = directory.repository.current_stack
     patch_name = get_patch(stack, options.patch)

--- a/stgit/config.py
+++ b/stgit/config.py
@@ -32,20 +32,21 @@ class GitConfigException(StgException):
 
 class GitConfig(object):
     __defaults = {
-        'stgit.smtpserver':     ['localhost:25'],
-        'stgit.smtpdelay':      ['5'],
-        'stgit.pullcmd':        ['git pull'],
-        'stgit.fetchcmd':       ['git fetch'],
-        'stgit.pull-policy':    ['pull'],
-        'stgit.autoimerge':     ['no'],
-        'stgit.keepoptimized':  ['no'],
-        'stgit.shortnr':        ['5'],
-        'stgit.pager':          ['less'],
-        'stgit.alias.add':      ['git add'],
-        'stgit.alias.rm':       ['git rm'],
-        'stgit.alias.mv':       ['git mv'],
-        'stgit.alias.resolved': ['git add'],
-        'stgit.alias.status':   ['git status -s']
+        'stgit.smtpserver':        ['localhost:25'],
+        'stgit.smtpdelay':         ['5'],
+        'stgit.pullcmd':           ['git pull'],
+        'stgit.fetchcmd':          ['git fetch'],
+        'stgit.pull-policy':       ['pull'],
+        'stgit.autoimerge':        ['no'],
+        'stgit.keepoptimized':     ['no'],
+        'stgit.refreshsubmodules': ['no'],
+        'stgit.shortnr':           ['5'],
+        'stgit.pager':             ['less'],
+        'stgit.alias.add':         ['git add'],
+        'stgit.alias.rm':          ['git rm'],
+        'stgit.alias.mv':          ['git mv'],
+        'stgit.alias.resolved':    ['git add'],
+        'stgit.alias.status':      ['git status -s']
     }
 
     __cache = None

--- a/stgit/config.py
+++ b/stgit/config.py
@@ -91,6 +91,30 @@ class GitConfig(object):
             raise GitConfigException('Value for "%s" is not an integer: "%s"' %
                                      (name, value))
 
+    def getbool(self, name):
+        """Report the canonicalized boolean value for a given key."""
+        # We cannot directly call get() because we need to use the KeyError in
+        # order to distinguish between the case of a key with an undefined
+        # value, and a completely undefined key. Git expects the former to be
+        # reported as "true".
+        self.load()
+        try:
+            value = self.__cache[name][-1]
+        except KeyError:
+            return None
+        if value is None:
+            # The key is defined, but the value is not, so treat it as true.
+            return True
+        elif value in ['yes', 'on', 'true']:
+            return True
+        elif value in ['no', 'off', 'false', '']:
+            return False
+        elif value.isdigit():
+            return bool(value)
+        else:
+            raise GitConfigException('Value for "%s" is not a booleain: "%s"' %
+                                     (name, value))
+
     def getstartswith(self, name):
         self.load()
         return ((n, v[-1]) for (n, v) in self.__cache.items()

--- a/stgit/config.py
+++ b/stgit/config.py
@@ -60,7 +60,11 @@ class GitConfig(object):
         lines = Run('git', 'config', '--null', '--list'
                     ).discard_exitcode().output_lines('\0')
         for line in lines:
-            key, value = line.split('\n', 1)
+            try:
+                key, value = line.split('\n', 1)
+            except ValueError:
+                key = line
+                value = None
             self.__cache.setdefault(key, []).append(value)
 
     def get(self, name):

--- a/stgit/git.py
+++ b/stgit/git.py
@@ -607,7 +607,7 @@ def merge_recursive(base, head1, head2):
     output = p.output_lines()
     if p.exitcode:
         # There were conflicts
-        if config.get('stgit.autoimerge') == 'yes':
+        if config.getbool('stgit.autoimerge'):
             mergetool()
         else:
             conflicts = [l for l in output if l.startswith('CONFLICT')]

--- a/stgit/lib/git.py
+++ b/stgit/lib/git.py
@@ -815,6 +815,15 @@ class Repository(RunWithEnv):
                 return None
         finally:
             index.delete()
+    def submodules(self, tree):
+        """Given a L{Tree}, return list of paths which are submodules."""
+        assert isinstance(tree, Tree)
+        # A simple regex to match submodule entries
+        regex = re.compile(r'160000 commit [0-9a-f]{40}\t(.*)$')
+        # First, use ls-tree to get all the trees and links
+        files = self.run(['git', 'ls-tree', '-d', '-r', '-z', tree.sha1]).output_lines('\0')
+        # Then extract the paths of any submodules
+        return set(m.group(1) for m in map(regex.match, files) if m)
     def diff_tree(self, t1, t2, diff_opts, binary = True):
         """Given two L{Tree}s C{t1} and C{t2}, return the patch that takes
         C{t1} to C{t2}.

--- a/stgit/lib/git.py
+++ b/stgit/lib/git.py
@@ -1086,7 +1086,7 @@ class IndexAndWorktree(RunWithEnvCwd):
     def worktree_clean(self):
         """Check whether the worktree is clean relative to index."""
         try:
-            self.run(['git', 'update-index', '--refresh']).discard_output()
+            self.run(['git', 'update-index', '--ignore-submodules', '--refresh']).discard_output()
         except RunException:
             return False
         else:

--- a/stgit/lib/transaction.py
+++ b/stgit/lib/transaction.py
@@ -362,7 +362,7 @@ class StackTransaction(object):
                 self.__halt('Index/worktree dirty')
             try:
                 interactive = (allow_interactive and
-                               config.get('stgit.autoimerge') == 'yes')
+                               config.getbool('stgit.autoimerge'))
                 iw.merge(base, ours, theirs, interactive = interactive)
                 tree = iw.index.write_tree()
                 self.__current_tree = tree

--- a/t/t1200-push-modified.sh
+++ b/t/t1200-push-modified.sh
@@ -71,4 +71,20 @@ test_expect_success \
     )
 '
 
+test_expect_success \
+    'pop then push a patch with a change to a submodule should not produce a conflict' '
+    (
+        cd bar &&
+        stg clone ../foo baz &&
+        stg new p3 -m p3 &&
+        git submodule add ../foo baz &&
+        stg refresh &&
+        (cd baz && git reset --hard HEAD^) &&
+        stg new p4 -m p4 &&
+        stg refresh &&
+        stg pop &&
+        stg push
+    )
+'
+
 test_done

--- a/t/t5000-refresh-submodules.sh
+++ b/t/t5000-refresh-submodules.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+#
+# Copyright (c) 2017 Intel Corporation
+#
+
+test_description='Refresh with submodules'
+
+. ./test-lib.sh
+
+test_expect_success 'refresh with a submodule does not include by default' '
+  test_create_repo foo &&
+  git submodule add ./foo foo &&
+  git commit -m "submodule" &&
+  stg init &&
+  (
+    cd foo &&
+    touch file1 &&
+    git add file1 &&
+    git commit -m "change in submodule"
+  ) &&
+  stg new p1 -m p1 &&
+  stg refresh &&
+  [ "$(stg status)" == " M foo" ]
+'
+
+test_expect_success 'refresh includes non-submodule changes' '
+  touch file2 &&
+  git add file2 &&
+  stg refresh &&
+  [ "$(stg status)" == " M foo" ]
+'
+
+test_expect_success 'refresh with --submodules' '
+  stg refresh --submodules &&
+  [ "$(stg status)" == "" ]
+'
+
+test_expect_success 'refresh --no-submodules overrides config' '
+  stg undo && stg undo &&
+  git config stgit.refreshsubmodules yes &&
+  stg refresh --no-submodules &&
+  [ "$(stg status)" == " M foo" ]
+'
+
+test_expect_success 'refresh with config' '
+   stg refresh &&
+   [ "$(stg status)" == "" ]
+'
+
+test_done

--- a/t/t6000-config.sh
+++ b/t/t6000-config.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Copyright (c) 2017 Intel Corporation
+#
+
+test_description='Simple configuration tests'
+
+. ./test-lib.sh
+
+# Note that it is not possible to use git-config to write such a value, but
+# they are expected to be interpret-able by git commands
+test_expect_success 'stg accepts keys without values' '
+  echo "[stgit]" >> .git/config &&
+  echo "	aboolean" >> .git/config &&
+  stg init &&
+  stg status
+'
+
+test_done


### PR DESCRIPTION
When refreshing patches, the default action is to include every path
which is changed relative to the current working directory. This common
workflow creates problems when one uses a submodule. Due to the nature
of submodules, under some workflows they can often be out-of-sync, such
as when working on new updates within a submodule.

Accidental refreshes which include the submodule changes often occur,
which leads to commits which unintentionally include changes to
submodule pointers. These commits likely cause submodules to point to
incorrect locations.

Since it is not easy to convince many developers to always use "refresh
--index", instead, modify the default refresh behavior.

Instead of including all files, now check to make sure that we exclude
submodule files.

We can do this by using git ls-tree to list the files and their modes.
To avoid re-running ls-tree many times, we'll use a compiled regex to
match lines that look like submodules, and extract their filename.

Add a new option to refresh "--submodules" which tells refresh to
include submodules regardless. Additionally, add a "--no-submodules" and
a stg.refreshsubmodules configuration so that users may opt to configure
this behavior.

Since the number of users who use submodules is likely small, make this
the new default behavior.

Signed-off-by: Jacob Keller <jacob.e.keller@intel.com>