### PR TITLE
Repair t2000-sync regression

### DIFF
--- a/stgit/commands/export.py
+++ b/stgit/commands/export.py
@@ -3,6 +3,7 @@
 
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+import io
 import os
 import sys
 
@@ -171,7 +172,7 @@ def func(parser, options, args):
         if options.stdout:
             f = sys.stdout
         else:
-            f = open(pfile, 'w+')
+            f = io.open(pfile, 'w+', encoding='utf-8')
 
         if options.stdout and num > 1:
             print('-'*79)

--- a/stgit/git.py
+++ b/stgit/git.py
@@ -3,6 +3,7 @@
 
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+import io
 import os
 import re
 import sys
@@ -779,7 +780,7 @@ def apply_patch(filename = None, diff = None, base = None,
     """
     if diff is None:
         if filename:
-            with open(filename) as f:
+            with io.open(filename, encoding='utf-8') as f:
                 diff = f.read()
         else:
             diff = sys.stdin.read()


### PR DESCRIPTION
When exporting, we now open the patch files with explicit utf-8 encoding.
Without explicitly choosing the encoding, it defaults to the locale
encoding which is C/ASCII in the test environment.

We similarly use utf-8 encoding when opening patch files to be applied
(i.e. for `stg sync`).

Signed-off-by: Peter Grayson <jpgrayson@gmail.com>