### PR TITLE
Replace dict comprehension for Python 2.6 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,7 @@ def __run_setup():
               'Operating System :: OS Independent',
               'Programming Language :: Python',
               'Programming Language :: Python :: 2',
+              'Programming Language :: Python :: 2.6',
               'Programming Language :: Python :: 2.7',
               'Programming Language :: Python :: 3',
               'Programming Language :: Python :: 3.3',

--- a/stgit/compat.py
+++ b/stgit/compat.py
@@ -48,8 +48,8 @@ if sys.version_info[0] <= 2:
             return fsdecode_utf8(b)
 
     def environ_copy():
-        return {fsdecode_utf8(k): fsdecode_utf8(v)
-                for k, v in os.environ.iteritems()}
+        return dict((fsdecode_utf8(k), fsdecode_utf8(v))
+                    for k, v in os.environ.iteritems())
 
 else:  # Python 3
     def fsdecode_utf8(b):

--- a/stgit/run.py
+++ b/stgit/run.py
@@ -92,8 +92,8 @@ class Run(object):
 
     def __prep_env(self):
         if self.__env:
-            return {fsencode_utf8(k): fsencode_utf8(v)
-                    for k, v in self.__env.items()}
+            return dict((fsencode_utf8(k), fsencode_utf8(v))
+                        for k, v in self.__env.items())
         else:
             return self.__env
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py33,py34,py35,py36
+envlist = py26,py27,pypy,py33,py34,py35,py36
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
With this dict comprehension replaced, unit tests pass with Python 2.6.

Repairs #13.

Signed-off-by: Peter Grayson <jpgrayson@gmail.com>