### PR TITLE
Handle utf-8 email bodies with latin-1 characters

### DIFF
--- a/stgit/commands/common.py
+++ b/stgit/commands/common.py
@@ -2,13 +2,14 @@
 """Function/variables common to all the commands"""
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+import codecs
 import email.utils
 import os
 import re
 import sys
 
 from stgit import stack, git, templates
-from stgit.compat import text
+from stgit.compat import text, decode_utf8_with_latin1
 from stgit.config import config
 from stgit.exception import StgException
 from stgit.lib import git as libgit
@@ -444,7 +445,10 @@ def parse_mail(msg):
                                        'application/octet-stream']:
             payload = part.get_payload(decode=True)
             charset = part.get_content_charset('utf-8')
-            msg_text += payload.decode(charset)
+            if codecs.lookup(charset).name == 'utf-8':
+                msg_text += decode_utf8_with_latin1(payload)
+            else:
+                msg_text += payload.decode(charset)
 
     rem_descr, diff = __split_descr_diff(msg_text)
     if rem_descr:

--- a/t/t1800-import.sh
+++ b/t/t1800-import.sh
@@ -98,6 +98,18 @@ test_expect_success \
     '
 
 test_expect_success \
+    'Apply a patch from latin1-encoded email specifying utf-8 charset' \
+    '
+    iconv -f UTF8 -t LATIN1 -o email-latin1 $STG_ROOT/t/t1800-import/email-8bit &&
+    stg import -m email-latin1 &&
+    [ $(git cat-file -p $(stg id) \
+        | grep -c "tree 030be42660323ff2a1958f9ee79589a4f3fbee2f") = 1 ] &&
+    [ $(git cat-file -p $(stg id) \
+        | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+    stg delete ..
+    '
+
+test_expect_success \
     'Apply a patch from a QP-encoded e-mail' \
     '
     stg import -m $STG_ROOT/t/t1800-import/email-qp &&


### PR DESCRIPTION
It is possible for emails to specify a utf-8 charset, but erroneously
contain latin-1 encoded characters. Reference:

  https://lkml.org/lkml/2018/1/24/704

Instead of failing import with a decoding error, stgit now takes the same
approach as git by decoding non-utf8 bytes as latin-1.

Signed-off-by: Peter Grayson <jpgrayson@gmail.com>