### PR TITLE
Decode email headers with quoted encoded words

### DIFF
--- a/t/t1800-import.sh
+++ b/t/t1800-import.sh
@@ -98,6 +98,17 @@ test_expect_success \
     '
 
 test_expect_success \
+    'Apply a patch from email with quoted "From" header' \
+    '
+    stg import -m $STG_ROOT/t/t1800-import/email-quoted-from &&
+    [ $(git cat-file -p $(stg id) \
+        | grep -c "tree 030be42660323ff2a1958f9ee79589a4f3fbee2f") = 1 ] &&
+    [ $(git cat-file -p $(stg id) \
+        | grep -c "author Inge Ström <inge@power.com>") = 1 ] &&
+    stg delete ..
+    '
+
+test_expect_success \
     'Apply a patch from a QP-encoded e-mail' \
     '
     stg import -m $STG_ROOT/t/t1800-import/email-qp &&

--- a/t/t1800-import/email-quoted-from
+++ b/t/t1800-import/email-quoted-from
@@ -1,0 +1,37 @@
+From: "Inge =?utf-8?q?Str=C3=B6m?=" <inge@power.com>
+Subject: [PATCH] test patch
+To: Upstream <foo@bar.baz>
+Date: Sat, 11 Nov 2006 11:58:14 +0100
+Message-ID: <20061111105814.23209.46952.stgit@localhost>
+User-Agent: StGIT/0.11
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Inge Ström <inge@power.com>
+---
+
+ foo.txt |    2 ++
+ 1 files changed, 2 insertions(+), 0 deletions(-)
+
+diff --git a/foo.txt b/foo.txt
+index ad01662..d3cd5b6 100644
+--- a/foo.txt
++++ b/foo.txt
+@@ -3,6 +3,7 @@ dobedim
+ dobedum
+ dobidam
+ dobidim
++pum-pöddelipåm
+ dobidum
+ dobodam
+ dobodim
+@@ -20,6 +21,7 @@ dabedam
+ dabedim
+ dabedum
+ dabidam
++pum-däddelidum
+ dabidim
+ dabidum
+ dabodam
+


### PR DESCRIPTION
Although not clearly RFC-2047 compliant, there are cases in the wild where
email headers contain encoded words within quotes. E.g.:

  From: "=?UTF-8?q?Christian=20K=C3=B6nig?=" <name@example.com>

Python2 and Python3 have different behavior when parsing such a header
using email.header.decode_words(). Python3 will decode the encoded words
between the quotes whereas Python2 will leave the encoded words in their
encoded state. The goal for this change is to make Python2 behave as
Python3.

A regular expression (email.header.ecre) is used in
email.header.decode_header() to detect and parse encoded words. This regex
is subtly different between Python2 and Python3--the Python2 regex requires
whitespace or the end-of-string after encoded words whereas Python3 does
not. Monkey-patching the Python2 email.header.ecre regex to not require
trailing whitespace is sufficient to make Python2 behave the same as
Python3.

A new test is added to t1800-import.sh to verify this behavior.

Signed-off-by: Peter Grayson <jpgrayson@gmail.com>