### PR TITLE
Travis-CI and Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+dist: trusty
+sudo: false
+
+language: python
+
+matrix:
+  include:
+    - python: '2.6'
+      env: MAKE_TARGET=test
+    - python: '2.7'
+      env: MAKE_TARGET=coverage-test
+    - python: 'pypy'
+      env: MAKE_TARGET=test
+    - python: '3.3'
+      env: MAKE_TARGET=test
+    - python: '3.4'
+      env: MAKE_TARGET=test
+    - python: '3.5'
+      env: MAKE_TARGET=test
+    - python: '3.6'
+      env: MAKE_TARGET=coverage-test
+    - python: 'pypy3'
+      env: MAKE_TARGET=test
+    - python: 'nightly'
+      env: MAKE_TARGET=test
+  allow_failures:
+    - python: 'nightly'
+    - python: '2.6'
+
+install:
+  - pip install coveralls
+
+script: make $MAKE_TARGET
+
+after_success:
+  coveralls
+
+cache:
+- pip

--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,14 @@ test_patches:
 		stg goto $$patch && $(MAKE) test || break; \
 	done
 
-coverage:
+coverage: coverage-test coverage-report
+
+coverage-test:
 	$(PYTHON) -m coverage run setup.py build
 	COVERAGE_PROCESS_START=$(PWD)/.coveragerc $(MAKE) -C t all
 	$(PYTHON) -m coverage combine $$(find . -name '.coverage.*')
+
+coverage-report:
 	$(PYTHON) -m coverage html --title="stgit coverage"
 	$(PYTHON) -m coverage report
 	@echo "HTML coverage report: file://$(PWD)/htmlcov/index.html"
@@ -55,4 +59,4 @@ TAGS:
 	ctags -e -R stgit/*
 
 .PHONY: all install doc install-doc install-html test test_patches \
-	coverage clean tags TAGS
+	coverage coverage-test coverage-report clean tags TAGS


### PR DESCRIPTION
Add a `.travis.yml` file to allow stgit to be tested using the Travis-CI service. This uses Travis' containerized environments (as opposed to the slower VM environments). The tests cover nine python versions from 2.6 through 3.7 (nightly), including pypy and pypy3.

We capture code coverage data during the python 2.7 and python 3.6 tests. That coverage data is uploaded to the Coveralls service which tracks code coverage over time as well as providing a web-based view of coverage over individual files.

The test and coverage outcomes for my fork can be seen here:

- https://travis-ci.org/jpgrayson/stgit
- https://coveralls.io/github/jpgrayson/stgit

If this PR is accepted, I would also propose enabling Travis-CI and Coveralls on the upstream `ctmarinas/stgit` repo. In addition to performing tests on commits pushed directly to the repo, enabling Travis-CI on `ctmarinas/stgit` would also cause any submitted PR's to be automatically tested.