### PR TITLE
Add --overwrite option for publish.

### DIFF
--- a/stgit/commands/publish.py
+++ b/stgit/commands/publish.py
@@ -91,6 +91,11 @@ options = [
         action='store_true',
         short='Show applied patches that have not been published',
     ),
+    opt(
+        '--overwrite',
+        action='store_true',
+        short='Overwrite branch instead of creating new commits',
+    ),
 ] + (
     argparse.author_options()
     + argparse.message_options(save_template=False)
@@ -178,6 +183,11 @@ def func(parser, options, args):
         for p in stack.patchorder.applied:
             if p not in published:
                 print(p)
+        return
+
+    if options.overwrite:
+        repository.refs.set(public_ref, stack.head, 'publish')
+        out.info('Overwrote "%s"' % public_ref)
         return
 
     # check for rebased stack. In this case we emulate a merge with the stack

--- a/t/t4100-publish.sh
+++ b/t/t4100-publish.sh
@@ -46,6 +46,18 @@ test_expect_success \
 	'
 
 test_expect_success \
+	'Fix a mistake and overwrite publish the fix' \
+	'
+	initial_patch_count=$(git rev-list master.public | wc -l) &&
+	echo fix >> fix.txt &&
+	stg add fix.txt &&
+	stg refresh &&
+	stg publish --overwrite &&
+	test_same_tree &&
+	test $(git rev-list master.public | wc -l) -eq $initial_patch_count
+	'
+
+test_expect_success \
 	'Modify a patch and publish the changes' \
 	'
 	stg pop &&


### PR DESCRIPTION
This option is useful for 'github style'
pull requests where it is often requested
to rewrite your pull request multiple
times before it is accepted.