### PR TITLE
setup.py: include lib.git submodule

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,7 +110,8 @@ setup(
     description='Stacked GIT',
     long_description='Push/pop utility on top of GIT',
     scripts=['stg'],
-    packages=list(map(str, ['stgit', 'stgit.commands', 'stgit.lib'])),
+    packages=list(map(str, ['stgit', 'stgit.commands',
+                            'stgit.lib', 'stgit.lib.git'])),
     data_files=[
         ('share/stgit/templates', glob('stgit/templates/*.tmpl')),
         ('share/stgit/examples', glob('examples/*.tmpl')),


### PR DESCRIPTION
stgit.lib.git doesn't appear to be included otherwise.

While we're here, delete a list(map(str, [...])) invocation that
seemingly does nothing.

Might be an appropriate fix for issue #37.