### PR TITLE
out.py: prefer stderr and remove isatty() restriction

### DIFF
--- a/stgit/out.py
+++ b/stgit/out.py
@@ -99,10 +99,7 @@ class MessagePrinter(object):
                     sys.stderr.fileno(), 'w', buffering=1, encoding='utf-8'
                 )
             )
-        if file or sys.stdout.isatty():
-            self.__out = self.__stdout
-        else:
-            self.__out = Output(None)
+        self.__out = self.__stdout
 
     def stdout(self, line):
         """Write a line to stdout."""

--- a/stgit/out.py
+++ b/stgit/out.py
@@ -127,10 +127,10 @@ class MessagePrinter(object):
 
     def info(self, *msgs):
         for msg in msgs:
-            self.__out.single_line(msg)
+            self.__stderr.single_line(msg)
 
     def note(self, *msgs, **kw):
-        self.__out.tagged_lines(kw.get('title', 'Notice'), msgs)
+        self.__stderr.tagged_lines(kw.get('title', 'Notice'), msgs)
 
     def warn(self, *msgs, **kw):
         self.__stderr.tagged_lines(kw.get('title', 'Warning'), msgs)


### PR DESCRIPTION
Maybe this is good enough for now to close #35.

By changing .info() and .note() to stderr, we can slacken the isatty() restriction and get away with no test breakages. Seems fairly clean; though of course this is still a change in behavior that might break fragile scripts.