### PR TITLE
Make the build reproducible

### DIFF
--- a/stgit/commands/__init__.py
+++ b/stgit/commands/__init__.py
@@ -73,7 +73,7 @@ def get_commands(allow_cached=True):
 def py_commands(commands, f):
     f.write('from __future__ import unicode_literals\n\n')
     f.write('command_list = {\n')
-    for name, (mod, kind, help) in commands.items():
+    for name, (mod, kind, help) in sorted(commands.items()):
         f.write('    %r: (\n' % name)
         f.write('        %r,\n' % mod)
         f.write('        %r,\n' % kind)

--- a/stgit/completion/bash.py
+++ b/stgit/completion/bash.py
@@ -26,7 +26,7 @@ class CompgenBase(object):
             cmd += ['-A', act]
         words = self.words(var)
         if words:
-            cmd += ['-W', '"%s"' % ' '.join(words)]
+            cmd += ['-W', '"%s"' % ' '.join(sorted(words))]
         cmd += ['--', '"%s"' % var]
         return ' '.join(cmd)
 
@@ -76,7 +76,7 @@ class patch_range(CompgenBase):
             for e_word in e.words(var):
                 if e_word not in words:
                     words.append(e_word)
-        return ['$(_patch_range "%s" "%s")' % (' '.join(words), var)]
+        return ['$(_patch_range "%s" "%s")' % (' '.join(sorted(words)), var)]
 
 
 def compjoin(compgens):


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/) we noticed that stgit could not be built reproducibly.

This is because the contents of the dynamically-compiled Bash completion script was not being generated in a deterministic manner, as well as the `cmdlist.py` module.

This was originally filed in Debian as [#942009](https://bugs.debian.org/942009).