### PR TITLE
Fix importing mail with CRLF rather than LF

### DIFF
--- a/stgit/commands/common.py
+++ b/stgit/commands/common.py
@@ -561,11 +561,14 @@ def update_commit_data(cd, options):
             add_sign_line(cd.message, sign_str,
                           cd.committer.name, cd.committer.email))
 
-    # Let user edit the commit message manually, unless
-    # --save-template or --message was specified.
+    # Edit the commit message manually if:
+    # - A message was specified, but --edit was also specified.
+    # - No message was specified, and --save_template was also not specified
     if (
-        not getattr(options, 'save_template', None)
-        and getattr(options, 'message', None) is None
+        (getattr(cd, 'message', None)
+         and getattr(options, 'edit', None))
+        or (not getattr(cd, 'message', None)
+            and not getattr(options, 'save_template', None))
     ):
         tmpl = templates.get_template('patchdescr.tmpl')
         if tmpl:

--- a/stgit/commands/common.py
+++ b/stgit/commands/common.py
@@ -428,7 +428,7 @@ def __parse_description(descr):
     return (subject + body, authname, authemail, authdate)
 
 
-def parse_mail(msg):
+def parse_mail(msg, options):
     """Parse the message object and return (description, authname,
     authemail, authdate, diff)
     """
@@ -482,6 +482,14 @@ def parse_mail(msg):
                                        'application/octet-stream']:
             payload = part.get_payload(decode=True)
             msg_data += payload
+
+    # RFC-compliant mail uses CRLF.  Replace this with LF unless
+    # otherwise instructed.
+    if not getattr(options, 'keepcr', False):
+        msg_data_lf = b''
+        for line in msg_data.splitlines():
+            msg_data_lf += line + b'\n'
+        msg_data = msg_data_lf
 
     rem_descr, diff = __split_descr_diff(msg_data)
     if rem_descr:

--- a/stgit/commands/imprt.py
+++ b/stgit/commands/imprt.py
@@ -149,6 +149,11 @@ options = [
         action='store_true',
         short='Show the patch content in the editor buffer',
     ),
+    opt(
+        '--keepcr',
+        action='store_true',
+        short='Do not strip carriage returns when importing mail messages',
+    ),
 ] + argparse.author_options() + argparse.sign_options()
 
 directory = DirectoryHasRepository()
@@ -289,7 +294,7 @@ def __import_file(filename, options, patch=None):
             raise CmdException('error parsing the e-mail file: %s' % str(ex))
         (
             message, author_name, author_email, author_date, diff
-        ) = parse_mail(msg)
+        ) = parse_mail(msg, options)
     else:
         patch_str = f.read()
         (
@@ -370,7 +375,7 @@ def __import_mbox(filename, options):
                  author_name,
                  author_email,
                  author_date,
-                 diff) = parse_mail(msg)
+                 diff) = parse_mail(msg, options)
                 __create_patch(None, message, author_name, author_email,
                                author_date, diff, options)
     finally:


### PR DESCRIPTION
I've been having trouble importing some patch series due to CRLF incompatibilities.  This strips the CR from incoming mail by default before processing, unless `--keepcr` is specified (similar to the behavior of `git am`).

It also includes a fix to the development branch where `stg import` always edits every commit even though `--edit` wasn't specified.