### PR TITLE
Proposed (RFC)

### DIFF
--- a/stgit/commands/common.py
+++ b/stgit/commands/common.py
@@ -425,7 +425,7 @@ def __parse_description(descr):
     if lasthdr < end:
         body = '\n' + '\n'.join(l[descr_strip:] for l in descr_lines[lasthdr:])
 
-    return (subject + body, authname, authemail, authdate)
+    return (subject + body + '\n', authname, authemail, authdate)
 
 
 def parse_patch(patch_data, contains_diff):

--- a/stgit/commands/edit.py
+++ b/stgit/commands/edit.py
@@ -177,6 +177,9 @@ def func(parser, options, args):
                 failed('The commit-msg hook failed.')
             raise
 
+    # Refresh the committer information
+    cd = cd.set_committer(None)
+
     # The patch applied, so now we have to rewrite the StGit patch
     # (and any patches on top of it).
     iw = stack.repository.default_iw

--- a/stgit/commands/refresh.py
+++ b/stgit/commands/refresh.py
@@ -396,7 +396,8 @@ def func(parser, options, args):
             assert not failed_diff
         if not options.no_verify and (options.edit or cd.message != orig_msg):
             cd = run_commit_msg_hook(stack.repository, cd, options.edit)
-        return cd
+        # Refresh the committer information
+        return cd.set_committer(None)
 
     return absorb(stack, patch_name, temp_name, edit_fun,
                   annotate=options.annotate)

--- a/stgit/lib/git/repository.py
+++ b/stgit/lib/git/repository.py
@@ -431,3 +431,8 @@ class Repository(object):
     def repack(self):
         """Repack all objects into a single pack."""
         self.run(['git', 'repack', '-a', '-d', '-f']).run()
+
+    def copy_notes(self, old_sha1, new_sha1):
+        """Copy git notes from the old object to the new one."""
+        p = self.run(['git', 'notes', 'copy', old_sha1, new_sha1])
+        p.discard_exitcode().discard_stderr().discard_output()

--- a/stgit/lib/stack.py
+++ b/stgit/lib/stack.py
@@ -107,8 +107,14 @@ class Patch(object):
             pass
 
     def set_commit(self, commit, msg):
+        try:
+            old_sha1 = self.commit.sha1
+        except KeyError:
+            old_sha1 = None
         self._write_compat_files(commit, msg)
         self._stack.repository.refs.set(self._ref, commit, msg)
+        if old_sha1 and old_sha1 != commit.sha1:
+            self._stack.repository.copy_notes(old_sha1, commit.sha1)
 
     def set_name(self, name, msg):
         commit = self.commit

--- a/t/t1200-push-modified.sh
+++ b/t/t1200-push-modified.sh
@@ -23,8 +23,10 @@ test_expect_success \
     stg clone foo bar &&
     (
         cd bar && stg new p1 -m p1 &&
+        git notes add -m note1 &&
         printf "a\nc\n" > file && stg add file && stg refresh &&
         stg new p2 -m p2 &&
+        git notes add -m note2 &&
         printf "a\nb\nc\n" > file && stg refresh &&
         [ "$(echo $(stg series --applied --noprefix))" = "p1 p2" ] &&
         [ "$(echo $(stg series --unapplied --noprefix))" = "" ]
@@ -67,7 +69,9 @@ test_expect_success \
     (
         cd bar && stg push --merged --all
         [ "$(echo $(stg series --applied --noprefix))" = "p1 p2" ] &&
-        [ "$(echo $(stg series --unapplied --noprefix))" = "" ]
+        [ "$(echo $(stg series --unapplied --noprefix))" = "" ] &&
+        [ "$(git notes show $(stg id p1))" = "note1" ] &&
+        [ "$(git notes show)" = "note2" ]
     )
 '
 

--- a/t/t1208-push-and-pop.sh
+++ b/t/t1208-push-and-pop.sh
@@ -28,6 +28,7 @@ test_expect_success \
     'Create ten patches' '
     for i in 0 1 2 3 4 5 6 7 8 9; do
         stg new p$i -m p$i;
+        git notes add -m note$i;
     done &&
     [ "$(echo $(stg series --applied --noprefix))" = "p0 p1 p2 p3 p4 p5 p6 p7 p8 p9" ] &&
     [ "$(echo $(stg series --unapplied --noprefix))" = "" ]
@@ -87,7 +88,8 @@ test_expect_success \
     'Pop all but seven patches' '
     stg pop -n -7 &&
     [ "$(echo $(stg series --applied --noprefix))" = "p0 p1 p2 p3 p4 p5 p6" ] &&
-    [ "$(echo $(stg series --unapplied --noprefix))" = "p7 p8 p9" ]
+    [ "$(echo $(stg series --unapplied --noprefix))" = "p7 p8 p9" ] &&
+    [ "$(git notes show)" = "note6" ]
 '
 
 test_expect_success \
@@ -108,7 +110,8 @@ test_expect_success \
     'Push two patches' '
     stg push -n 2 &&
     [ "$(echo $(stg series --applied --noprefix))" = "p0 p1" ] &&
-    [ "$(echo $(stg series --unapplied --noprefix))" = "p2 p3 p4 p5 p6 p7 p8 p9" ]
+    [ "$(echo $(stg series --unapplied --noprefix))" = "p2 p3 p4 p5 p6 p7 p8 p9" ] &&
+    [ "$(git notes show)" = "note1" ]
 '
 
 test_expect_success \
@@ -122,14 +125,16 @@ test_expect_success \
     'Push all but three patches' '
     stg push -n -3 &&
     [ "$(echo $(stg series --applied --noprefix))" = "p0 p1 p2 p3 p4 p5 p6" ] &&
-    [ "$(echo $(stg series --unapplied --noprefix))" = "p7 p8 p9" ]
+    [ "$(echo $(stg series --unapplied --noprefix))" = "p7 p8 p9" ] &&
+    [ "$(git notes show)" = "note6" ]
 '
 
 test_expect_success \
     'Push two patches in reverse' '
     stg push -n 2 --reverse
     [ "$(echo $(stg series --applied --noprefix))" = "p0 p1 p2 p3 p4 p5 p6 p8 p7" ] &&
-    [ "$(echo $(stg series --unapplied --noprefix))" = "p9" ]
+    [ "$(echo $(stg series --unapplied --noprefix))" = "p9" ] &&
+    [ "$(git notes show)" = "note7" ]
 '
 
 test_expect_success \

--- a/t/t1302-repair-interop.sh
+++ b/t/t1302-repair-interop.sh
@@ -29,7 +29,6 @@ test_expect_success 'Pop two patches with git reset' '
     git reset --hard HEAD~2 &&
     command_error stg refresh &&
     stg repair &&
-    stg refresh &&
     [ "$(echo $(stg series --applied --noprefix))" = "p0 p1 p2" ] &&
     [ "$(echo $(stg series --unapplied --noprefix))" = "p3 p4" ]
 '
@@ -44,7 +43,6 @@ test_expect_success 'Go to an unapplied patch with with git reset' '
     git reset --hard $(stg id p3) &&
     command_error stg refresh &&
     stg repair &&
-    stg refresh &&
     [ "$(echo $(stg series --applied --noprefix))" = "p0 p1 p2 p3" ] &&
     [ "$(echo $(stg series --unapplied --noprefix))" = "q0 p4" ]
 '

--- a/t/t2200-rebase.sh
+++ b/t/t2200-rebase.sh
@@ -19,6 +19,7 @@ test_expect_success \
 
 	stg branch --create stack &&
 	stg new p -m . &&
+	git notes add -m note &&
 	echo bar >> file1 &&
 	stg refresh
 	'
@@ -28,7 +29,8 @@ test_expect_success \
 	'
 	stg rebase master~1 &&
 	test `stg id stack:{base}` = `git rev-parse master~1` &&
-	test `stg series --applied -c` = 1
+	test `stg series --applied -c` = 1 &&
+	test "$(git notes show)" = "note"
 	'
 
 test_expect_success \

--- a/t/t2600-squash.sh
+++ b/t/t2600-squash.sh
@@ -8,6 +8,7 @@ test_expect_success 'Initialize StGit stack' '
     stg init &&
     for i in 0 1 2 3; do
         stg new p$i -m "foo $i" &&
+        git notes add -m note$i &&
         echo "foo $i" >> foo.txt &&
         stg add foo.txt &&
         stg refresh

--- a/t/t2700-refresh.sh
+++ b/t/t2700-refresh.sh
@@ -11,6 +11,7 @@ test_expect_success 'Initialize StGit stack' '
     echo show.txt >> .git/info/exclude &&
     echo diff.txt >> .git/info/exclude &&
     stg new p0 -m "base" &&
+    git notes add -m note0 &&
     for i in 1 2 3; do
         echo base >> foo$i.txt &&
         stg add foo$i.txt
@@ -18,6 +19,7 @@ test_expect_success 'Initialize StGit stack' '
     stg refresh &&
     for i in 1 2 3; do
         stg new p$i -m "foo $i" &&
+        git notes add -m note$i &&
         echo "foo $i" >> foo$i.txt &&
         stg refresh
     done
@@ -30,6 +32,7 @@ EOF
 test_expect_success 'Refresh top patch' '
     echo bar 3 >> foo3.txt &&
     stg refresh &&
+    test "$(git notes show)" = "note3" &&
     stg status &&
     test -z "$(stg status)" &&
     stg patches foo3.txt > patches.txt &&
@@ -44,6 +47,8 @@ test_expect_success 'Refresh middle patch' '
     stg status &&
     echo bar 2 >> foo2.txt &&
     stg refresh -p p2 &&
+    test "$(git notes show $(stg id p2))" = "note2" &&
+    test "$(git notes show)" = "note3" &&
     stg status &&
     test -z "$(stg status)" &&
     stg patches foo2.txt > patches.txt &&
@@ -58,6 +63,9 @@ test_expect_success 'Refresh bottom patch' '
     stg status &&
     echo bar 1 >> foo1.txt &&
     stg refresh -p p1 &&
+    test "$(git notes show $(stg id p1))" = "note1" &&
+    test "$(git notes show $(stg id p2))" = "note2" &&
+    test "$(git notes show)" = "note3" &&
     stg status &&
     test -z "$(stg status)" &&
     stg patches foo1.txt > patches.txt &&
@@ -103,11 +111,13 @@ EOF
 test_expect_success 'Refresh --index' '
     stg status &&
     stg new p4 -m "refresh_index" &&
+    git notes add -m note4
     echo baz 1 >> foo1.txt &&
     stg add foo1.txt &&
     echo blah 1 >> foo1.txt &&
     echo baz 2 >> foo2.txt &&
     stg refresh --index &&
+    test "$(git notes show)" = "note4" &&
     stg patches foo1.txt > patches.txt &&
     git diff HEAD^..HEAD > show.txt &&
     stg diff > diff.txt &&

--- a/t/t3300-edit.sh
+++ b/t/t3300-edit.sh
@@ -75,7 +75,7 @@ test_expect_success 'Set patch message with --file -' '
 '
 
 ( printf 'From: A Ú Thor <author@example.com>\nDate: <omitted>'
-  printf '\n\nPride and Prejudice' ) > expected-tmpl
+  printf '\n\nPride and Prejudice\n' ) > expected-tmpl
 omit_date () { sed "s/^Date:.*$/Date: <omitted>/" ; }
 
 test_expect_success 'Save template to file' '
@@ -103,7 +103,7 @@ test_expect_success 'Save template to stdout' '
 mkeditor ()
 {
     write_script "$1" <<EOF
-printf "\n$1" >> "\$1"
+printf "$1" >> "\$1"
 EOF
 }
 

--- a/t/t3300-edit.sh
+++ b/t/t3300-edit.sh
@@ -9,12 +9,16 @@ test_expect_success 'Setup' '
     git commit -m "Initial commit" &&
     sed "s/000/000xx/" foo > foo.tmp && mv foo.tmp foo &&
     git commit -a -m "First change" &&
+    git notes add -m note1 &&
     sed "s/111/111yy/" foo > foo.tmp && mv foo.tmp foo &&
     git commit -a -m "Second change" &&
+    git notes add -m note2 &&
     sed "s/222/222zz/" foo > foo.tmp && mv foo.tmp foo &&
     git commit -a -m "Third change" &&
+    git notes add -m note3 &&
     sed "s/333/333zz/" foo > foo.tmp && mv foo.tmp foo &&
     git commit -a -m "Fourth change" &&
+    git notes add -m note4 &&
     stg init &&
     stg uncommit -n 4 p &&
     stg pop -n 2 &&
@@ -41,25 +45,30 @@ rm -f diffedit
 test_expect_success 'Edit message of top patch' '
     test "$(msg HEAD)" = "Second change" &&
     stg edit p2 -m "Second change 2" &&
-    test "$(msg HEAD)" = "Second change 2"
+    test "$(msg HEAD)" = "Second change 2" &&
+    test "$(git notes show $(stg id p2))" = "note2"
 '
 
 test_expect_success 'Edit message of non-top patch' '
     test "$(msg HEAD^)" = "First change" &&
     stg edit p1 -m "First change 2" &&
-    test "$(msg HEAD^)" = "First change 2"
+    test "$(msg HEAD^)" = "First change 2" &&
+    test "$(git notes show $(stg id p1))" = "note1"
+
 '
 
 test_expect_success 'Edit message of unapplied patch' '
     test "$(msg $(stg id p3))" = "Third change" &&
     stg edit p3 -m "Third change 2" &&
-    test "$(msg $(stg id p3))" = "Third change 2"
+    test "$(msg $(stg id p3))" = "Third change 2" &&
+    test "$(git notes show $(stg id p3))" = "note3"
 '
 
 test_expect_success 'Edit message of hidden patch' '
     test "$(msg $(stg id p4))" = "Fourth change" &&
     stg edit p4 -m "Fourth change 2" &&
-    test "$(msg $(stg id p4))" = "Fourth change 2"
+    test "$(msg $(stg id p4))" = "Fourth change 2" &&
+    test "$(git notes show $(stg id p4))" = "note4"
 '
 
 test_expect_success 'Set patch message with --file <file>' '
@@ -245,7 +254,11 @@ test_expect_success 'Set patch tree' '
     test "$(git write-tree)" = "$p2tree" &&
     grep "^333$" foo &&
     stg edit --set-tree $p2tree p1 &&
-    test "$(echo $(stg series --empty --all))" = "+ p1 0> p2 - p3 ! p4"
+    test "$(echo $(stg series --empty --all))" = "+ p1 0> p2 - p3 ! p4" &&
+    test "$(git notes show $(stg id p1))" = "note1" &&
+    test "$(git notes show $(stg id p2))" = "note2" &&
+    test "$(git notes show $(stg id p3))" = "note3" &&
+    test "$(git notes show $(stg id p4))" = "note4"
 '
 
 test_done


### PR DESCRIPTION
Three more or less random commits:

- Resetting of the committer information on stg refresh and edit to bring it in line with 'git commit --ammend'.

- A change in newline at the end of the commit message. This makes it similar to git and also allows the test suite to pass on Mac OS X where sed -i always adds a newline and the end of the modified file.

- Support for 'git notes'. They are now preserved on refresh/push/pop/edit. The 'squash' and 'pick' commands do not handle git notes (maybe in a future patch but these create new patches without old commit information).

Please feel free to cherry-pick whichever patches you find appropriate or comment on whatever is missing/wrong.